### PR TITLE
MySQL: Change variable names to camelCaps

### DIFF
--- a/src/Lunr/Gravity/MySQL/MySQLAsyncQueryResult.php
+++ b/src/Lunr/Gravity/MySQL/MySQLAsyncQueryResult.php
@@ -73,11 +73,11 @@ class MySQLAsyncQueryResult extends MySQLQueryResult
 
         $this->fetched = TRUE;
 
-        $this->error_message = $this->mysqli->error;
-        $this->error_number  = $this->mysqli->errno;
-        $this->insert_id     = $this->mysqli->insert_id;
-        $this->affected_rows = mysqli_affected_rows($this->mysqli);
-        $this->num_rows      = is_object($this->result) ? mysqli_num_rows($this->result) : $this->affected_rows;
+        $this->errorMessage = $this->mysqli->error;
+        $this->errorNumber  = $this->mysqli->errno;
+        $this->insertId     = $this->mysqli->insert_id;
+        $this->affectedRows = mysqli_affected_rows($this->mysqli);
+        $this->numRows      = is_object($this->result) ? mysqli_num_rows($this->result) : $this->affectedRows;
     }
 
     /**

--- a/src/Lunr/Gravity/MySQL/MySQLConnection.php
+++ b/src/Lunr/Gravity/MySQL/MySQLConnection.php
@@ -27,13 +27,13 @@ class MySQLConnection extends DatabaseConnection
      * Hostname of the database server (read/write access)
      * @var string|null
      */
-    protected ?string $rw_host;
+    protected ?string $rwHost;
 
     /**
      * Hostname of the database server (readonly access)
      * @var string|null
      */
-    protected ?string $ro_host;
+    protected ?string $roHost;
 
     /**
      * Username of the user used to connect to the database
@@ -75,31 +75,31 @@ class MySQLConnection extends DatabaseConnection
      * SQL hint to send along with the query.
      * @var string
      */
-    protected string $query_hint;
+    protected string $queryHint;
 
     /**
      * The path name to the key file.
      * @var string|null
      */
-    protected ?string $ssl_key;
+    protected ?string $sslKey;
 
     /**
      * The path name to the certificate file.
      * @var string|null
      */
-    protected ?string $ssl_cert;
+    protected ?string $sslCert;
 
     /**
      * The path name to the certificate authority file.
      * @var string|null
      */
-    protected ?string $ca_cert;
+    protected ?string $caCert;
 
     /**
      * The pathname to a directory that contains trusted SSL CA certificates in PEM format.
      * @var string|null
      */
-    protected ?string $ca_path;
+    protected ?string $caPath;
 
     /**
      * A list of allowable ciphers to use for SSL encryption.
@@ -138,7 +138,7 @@ class MySQLConnection extends DatabaseConnection
 
         $this->mysqli =& $mysqli;
 
-        $this->query_hint                                 = '';
+        $this->queryHint                                  = '';
         $this->options[ MYSQLI_OPT_INT_AND_FLOAT_NATIVE ] = TRUE;
 
         $this->set_configuration();
@@ -158,18 +158,18 @@ class MySQLConnection extends DatabaseConnection
         }
 
         unset($this->mysqli);
-        unset($this->rw_host);
-        unset($this->ro_host);
+        unset($this->rwHost);
+        unset($this->roHost);
         unset($this->user);
         unset($this->pwd);
         unset($this->db);
         unset($this->port);
         unset($this->socket);
-        unset($this->query_hint);
-        unset($this->ssl_key);
-        unset($this->ssl_cert);
-        unset($this->ca_cert);
-        unset($this->ca_path);
+        unset($this->queryHint);
+        unset($this->sslKey);
+        unset($this->sslCert);
+        unset($this->caCert);
+        unset($this->caPath);
         unset($this->cipher);
 
         parent::__destruct();
@@ -182,23 +182,23 @@ class MySQLConnection extends DatabaseConnection
      */
     private function set_configuration(): void
     {
-        $this->rw_host  = $this->configuration['db']['rw_host'];
-        $this->user     = $this->configuration['db']['username'];
-        $this->pwd      = $this->configuration['db']['password'];
-        $this->db       = $this->configuration['db']['database'];
-        $this->ssl_key  = $this->configuration['db']['ssl_key'];
-        $this->ssl_cert = $this->configuration['db']['ssl_cert'];
-        $this->ca_cert  = $this->configuration['db']['ca_cert'];
-        $this->ca_path  = $this->configuration['db']['ca_path'];
-        $this->cipher   = $this->configuration['db']['cipher'];
+        $this->rwHost  = $this->configuration['db']['rw_host'];
+        $this->user    = $this->configuration['db']['username'];
+        $this->pwd     = $this->configuration['db']['password'];
+        $this->db      = $this->configuration['db']['database'];
+        $this->sslKey  = $this->configuration['db']['ssl_key'];
+        $this->sslCert = $this->configuration['db']['ssl_cert'];
+        $this->caCert  = $this->configuration['db']['ca_cert'];
+        $this->caPath  = $this->configuration['db']['ca_path'];
+        $this->cipher  = $this->configuration['db']['cipher'];
 
         if ($this->configuration['db']['ro_host'] != NULL)
         {
-            $this->ro_host = $this->configuration['db']['ro_host'];
+            $this->roHost = $this->configuration['db']['ro_host'];
         }
         else
         {
-            $this->ro_host = $this->rw_host;
+            $this->roHost = $this->rwHost;
         }
 
         if ($this->configuration['db']['port'] != NULL)
@@ -223,11 +223,11 @@ class MySQLConnection extends DatabaseConnection
     /**
      * Establishes a connection to the defined mysql-server.
      *
-     * @param int $reconnect_count How often we already tried to connect.
+     * @param int $reconnectCount How often we already tried to connect.
      *
      * @return void
      */
-    public function connect(int $reconnect_count = 0): void
+    public function connect(int $reconnectCount = 0): void
     {
         if ($this->connected === TRUE)
         {
@@ -239,16 +239,16 @@ class MySQLConnection extends DatabaseConnection
             throw new ConnectionException('Cannot connect to a non-mysql database connection!');
         }
 
-        if ($reconnect_count > static::RECONNECT_LIMIT)
+        if ($reconnectCount > static::RECONNECT_LIMIT)
         {
             throw new ConnectionException('Could not establish connection to the database! Exceeded reconnect count!');
         }
 
-        $host = ($this->readonly === TRUE) ? $this->ro_host : $this->rw_host;
+        $host = ($this->readonly === TRUE) ? $this->roHost : $this->rwHost;
 
-        if (isset($this->ssl_key, $this->ssl_cert, $this->ca_cert))
+        if (isset($this->sslKey, $this->sslCert, $this->caCert))
         {
-            $this->mysqli->ssl_set($this->ssl_key, $this->ssl_cert, $this->ca_cert, $this->ca_path, $this->cipher);
+            $this->mysqli->ssl_set($this->sslKey, $this->sslCert, $this->caCert, $this->caPath, $this->cipher);
         }
 
         foreach ($this->options as $key => $value)
@@ -266,7 +266,7 @@ class MySQLConnection extends DatabaseConnection
             {
                 // manual re-connect
                 $this->disconnect();
-                $this->connect(++$reconnect_count);
+                $this->connect(++$reconnectCount);
             }
         }
 
@@ -397,7 +397,7 @@ class MySQLConnection extends DatabaseConnection
         switch ($style)
         {
             case 'maxscale':
-                $this->query_hint = '/* maxscale route to master */';
+                $this->queryHint = '/* maxscale route to master */';
                 break;
             default:
                 break;
@@ -418,7 +418,7 @@ class MySQLConnection extends DatabaseConnection
         switch ($style)
         {
             case 'maxscale':
-                $this->query_hint = '/* maxscale route to slave */';
+                $this->queryHint = '/* maxscale route to slave */';
                 break;
             default:
                 break;
@@ -430,47 +430,47 @@ class MySQLConnection extends DatabaseConnection
     /**
      * Run a SQL query.
      *
-     * @param string $sql_query The SQL query to run on the database
+     * @param string $sqlQuery The SQL query to run on the database
      *
      * @return MySQLQueryResult $result Query Result
      */
-    public function query($sql_query): MySQLQueryResult
+    public function query($sqlQuery): MySQLQueryResult
     {
         $this->connect();
 
-        $sql_query        = $this->query_hint . $sql_query;
-        $this->query_hint = '';
+        $sqlQuery        = $this->queryHint . $sqlQuery;
+        $this->queryHint = '';
 
-        $this->logger->debug('query: {query}', [ 'query' => $sql_query ]);
+        $this->logger->debug('query: {query}', [ 'query' => $sqlQuery ]);
 
-        $query_start = microtime(TRUE);
-        $result      = $this->mysqli->query($sql_query);
-        $query_end   = microtime(TRUE);
+        $queryStart = microtime(TRUE);
+        $result     = $this->mysqli->query($sqlQuery);
+        $queryEnd   = microtime(TRUE);
 
-        $this->logger->debug('Query executed in ' . ($query_end - $query_start) . ' seconds');
+        $this->logger->debug('Query executed in ' . ($queryEnd - $queryStart) . ' seconds');
 
-        return new MySQLQueryResult($sql_query, $result, $this->mysqli);
+        return new MySQLQueryResult($sqlQuery, $result, $this->mysqli);
     }
 
     /**
      * Run an asynchronous SQL query.
      *
-     * @param string $sql_query The SQL query to run on the database
+     * @param string $sqlQuery The SQL query to run on the database
      *
      * @return MySQLAsyncQueryResult $result Query Result
      */
-    public function async_query(string $sql_query): MySQLAsyncQueryResult
+    public function async_query(string $sqlQuery): MySQLAsyncQueryResult
     {
         $this->connect();
 
-        $sql_query        = $this->query_hint . $sql_query;
-        $this->query_hint = '';
+        $sqlQuery        = $this->queryHint . $sqlQuery;
+        $this->queryHint = '';
 
-        $this->logger->debug('query: {query}', [ 'query' => $sql_query ]);
+        $this->logger->debug('query: {query}', [ 'query' => $sqlQuery ]);
 
-        $this->mysqli->query($sql_query, MYSQLI_ASYNC);
+        $this->mysqli->query($sqlQuery, MYSQLI_ASYNC);
 
-        return new MySQLAsyncQueryResult($sql_query, $this->mysqli);
+        return new MySQLAsyncQueryResult($sqlQuery, $this->mysqli);
     }
 
     /**

--- a/src/Lunr/Gravity/MySQL/MySQLQueryEscaper.php
+++ b/src/Lunr/Gravity/MySQL/MySQLQueryEscaper.php
@@ -152,15 +152,15 @@ class MySQLQueryEscaper extends DatabaseQueryEscaper
 
         $keyword = strtoupper($keyword);
 
-        $valid_keywords = [ 'USE', 'IGNORE', 'FORCE' ];
-        $valid_for      = [ 'JOIN', 'ORDER BY', 'GROUP BY', '' ];
+        $validKeywords = [ 'USE', 'IGNORE', 'FORCE' ];
+        $validFor      = [ 'JOIN', 'ORDER BY', 'GROUP BY', '' ];
 
-        if (!in_array($keyword, $valid_keywords))
+        if (!in_array($keyword, $validKeywords))
         {
             $keyword = 'USE';
         }
 
-        if (!in_array($for, $valid_for))
+        if (!in_array($for, $validFor))
         {
             $for = '';
         }

--- a/src/Lunr/Gravity/MySQL/MySQLQueryResult.php
+++ b/src/Lunr/Gravity/MySQL/MySQLQueryResult.php
@@ -40,7 +40,7 @@ class MySQLQueryResult implements DatabaseQueryResultInterface
      * The canonicalized query string that was executed.
      * @var string
      */
-    protected readonly string $canonical_query;
+    protected readonly string $canonicalQuery;
 
     /**
      * Return value from mysqli->query().
@@ -70,13 +70,13 @@ class MySQLQueryResult implements DatabaseQueryResultInterface
      * Description of the error.
      * @var string
      */
-    protected $error_message;
+    protected $errorMessage;
 
     /**
      * Error code.
      * @var int
      */
-    protected $error_number;
+    protected $errorNumber;
 
     /**
      * Warnings from Mysqli or NULL if no warnings
@@ -88,19 +88,19 @@ class MySQLQueryResult implements DatabaseQueryResultInterface
      * Autoincremented ID generated on last insert.
      * @var mixed
      */
-    protected $insert_id;
+    protected $insertId;
 
     /**
      * Number of affected rows.
      * @var int|string
      */
-    protected $affected_rows;
+    protected $affectedRows;
 
     /**
      * Number of rows in the result set.
      * @var int
      */
-    protected $num_rows;
+    protected $numRows;
 
     /**
      * Constructor.
@@ -129,11 +129,11 @@ class MySQLQueryResult implements DatabaseQueryResultInterface
 
         if ($async === FALSE)
         {
-            $this->error_message = $mysqli->error;
-            $this->error_number  = $mysqli->errno;
-            $this->insert_id     = $mysqli->insert_id;
-            $this->affected_rows = mysqli_affected_rows($mysqli);
-            $this->num_rows      = is_object($this->result) ? mysqli_num_rows($result) : $this->affected_rows;
+            $this->errorMessage = $this->mysqli->error;
+            $this->errorNumber  = $this->mysqli->errno;
+            $this->insertId     = $this->mysqli->insert_id;
+            $this->affectedRows = mysqli_affected_rows($this->mysqli);
+            $this->numRows      = is_object($this->result) ? mysqli_num_rows($result) : $this->affectedRows;
 
             $this->set_warnings();
         }
@@ -150,9 +150,9 @@ class MySQLQueryResult implements DatabaseQueryResultInterface
         unset($this->result);
         unset($this->success);
         unset($this->freed);
-        unset($this->error_message);
-        unset($this->error_number);
-        unset($this->insert_id);
+        unset($this->errorMessage);
+        unset($this->errorNumber);
+        unset($this->insertId);
         unset($this->query);
         unset($this->warnings);
     }
@@ -188,7 +188,7 @@ class MySQLQueryResult implements DatabaseQueryResultInterface
      */
     public function has_deadlock()
     {
-        return ($this->error_number == self::DEADLOCK_ERR_CODE) ? TRUE : FALSE;
+        return ($this->errorNumber == self::DEADLOCK_ERR_CODE) ? TRUE : FALSE;
     }
 
     /**
@@ -198,7 +198,7 @@ class MySQLQueryResult implements DatabaseQueryResultInterface
      */
     public function has_lock_timeout()
     {
-        return $this->error_number == self::LOCK_TIMEOUT_ERR_CODE;
+        return $this->errorNumber == self::LOCK_TIMEOUT_ERR_CODE;
     }
 
     /**
@@ -208,7 +208,7 @@ class MySQLQueryResult implements DatabaseQueryResultInterface
      */
     public function error_message()
     {
-        return $this->error_message;
+        return $this->errorMessage;
     }
 
     /**
@@ -218,7 +218,7 @@ class MySQLQueryResult implements DatabaseQueryResultInterface
      */
     public function error_number()
     {
-        return $this->error_number;
+        return $this->errorNumber;
     }
 
     /**
@@ -239,9 +239,9 @@ class MySQLQueryResult implements DatabaseQueryResultInterface
      */
     protected function set_warnings()
     {
-        $mysqli_warnings = $this->mysqli->get_warnings();
+        $mysqliWarnings = $this->mysqli->get_warnings();
 
-        if ($mysqli_warnings == FALSE)
+        if ($mysqliWarnings == FALSE)
         {
             $this->warnings = NULL;
             return;
@@ -249,13 +249,13 @@ class MySQLQueryResult implements DatabaseQueryResultInterface
 
         do
         {
-            $warning['message']  = $mysqli_warnings->message;
-            $warning['sqlstate'] = $mysqli_warnings->sqlstate;
-            $warning['errno']    = $mysqli_warnings->errno;
+            $warning['message']  = $mysqliWarnings->message;
+            $warning['sqlstate'] = $mysqliWarnings->sqlstate;
+            $warning['errno']    = $mysqliWarnings->errno;
 
             $this->warnings[] = $warning;
         }
-        while ($mysqli_warnings->next());
+        while ($mysqliWarnings->next());
     }
 
     /**
@@ -266,7 +266,7 @@ class MySQLQueryResult implements DatabaseQueryResultInterface
      */
     public function insert_id()
     {
-        return $this->insert_id;
+        return $this->insertId;
     }
 
     /**
@@ -288,7 +288,7 @@ class MySQLQueryResult implements DatabaseQueryResultInterface
      */
     public function affected_rows()
     {
-        return $this->affected_rows;
+        return $this->affectedRows;
     }
 
     /**
@@ -300,7 +300,7 @@ class MySQLQueryResult implements DatabaseQueryResultInterface
      */
     public function number_of_rows()
     {
-        return $this->num_rows;
+        return $this->numRows;
     }
 
     /**
@@ -315,14 +315,14 @@ class MySQLQueryResult implements DatabaseQueryResultInterface
     {
         $output = [];
 
-        $return_type = $associative ? MYSQLI_ASSOC : MYSQLI_NUM;
+        $returnType = $associative ? MYSQLI_ASSOC : MYSQLI_NUM;
 
         if (!is_object($this->result))
         {
             return $output;
         }
 
-        $output = $this->result->fetch_all($return_type);
+        $output = $this->result->fetch_all($returnType);
 
         $this->free_result();
 
@@ -397,12 +397,12 @@ class MySQLQueryResult implements DatabaseQueryResultInterface
      */
     public function canonical_query(): string
     {
-        if (isset($this->canonical_query) === FALSE)
+        if (isset($this->canonicalQuery) === FALSE)
         {
-            $this->canonical_query = new MySQLCanonicalQuery($this->query());
+            $this->canonicalQuery = new MySQLCanonicalQuery($this->query());
         }
 
-        return $this->canonical_query;
+        return $this->canonicalQuery;
     }
 
 }

--- a/src/Lunr/Gravity/MySQL/MySQLSimpleDMLQueryBuilder.php
+++ b/src/Lunr/Gravity/MySQL/MySQLSimpleDMLQueryBuilder.php
@@ -184,15 +184,15 @@ class MySQLSimpleDMLQueryBuilder implements DMLQueryBuilderInterface
     /**
      * Define a DELETE clause.
      *
-     * @param string $table_references The table references to delete from
+     * @param string $tableReferences The table references to delete from
      *
      * @return $this Self reference
      */
-    public function delete($table_references): static
+    public function delete($tableReferences): static
     {
         $tables = '';
 
-        foreach (explode(',', $table_references) as $table)
+        foreach (explode(',', $tableReferences) as $table)
         {
             $tables .= $this->escape_alias($table, TRUE) . ', ';
         }
@@ -273,15 +273,15 @@ class MySQLSimpleDMLQueryBuilder implements DMLQueryBuilderInterface
     /**
      * Define a UPDATE clause.
      *
-     * @param string $table_references The tables to update
+     * @param string $tableReferences The tables to update
      *
      * @return $this Self reference
      */
-    public function update($table_references): static
+    public function update($tableReferences): static
     {
         $tables = '';
 
-        foreach (explode(',', $table_references) as $table)
+        foreach (explode(',', $tableReferences) as $table)
         {
             $tables .= $this->escape_alias($table, TRUE) . ', ';
         }
@@ -313,44 +313,44 @@ class MySQLSimpleDMLQueryBuilder implements DMLQueryBuilderInterface
     /**
      * Define FROM clause of the SQL statement.
      *
-     * @param string $table_reference Table reference
-     * @param array  $index_hints     Array of Index Hints
+     * @param string $tableReference Table reference
+     * @param array  $indexHints     Array of Index Hints
      *
      * @return $this Self reference
      */
-    public function from($table_reference, $index_hints = NULL): static
+    public function from($tableReference, $indexHints = NULL): static
     {
-        $this->builder->from($this->escape_alias($table_reference), $index_hints);
+        $this->builder->from($this->escape_alias($tableReference), $indexHints);
         return $this;
     }
 
     /**
      * Define JOIN clause of the SQL statement.
      *
-     * @param string $table_reference Table reference
-     * @param string $type            Type of JOIN operation to perform.
-     * @param array  $index_hints     Array of Index Hints
+     * @param string $tableReference Table reference
+     * @param string $type           Type of JOIN operation to perform.
+     * @param array  $indexHints     Array of Index Hints
      *
      * @return $this Self reference
      */
-    public function join($table_reference, $type = 'INNER', $index_hints = NULL): static
+    public function join($tableReference, $type = 'INNER', $indexHints = NULL): static
     {
-        $this->builder->join($this->escape_alias($table_reference), $type, $index_hints);
+        $this->builder->join($this->escape_alias($tableReference), $type, $indexHints);
         return $this;
     }
 
     /**
      * Define USING part of the SQL statement.
      *
-     * @param string $column_list Columns to use.
+     * @param string $columnList Columns to use.
      *
      * @return $this Self reference
      */
-    public function using($column_list): static
+    public function using($columnList): static
     {
         $columns = '';
 
-        foreach (explode(',', $column_list) as $column)
+        foreach (explode(',', $columnList) as $column)
         {
             $columns .= $this->escaper->column(trim($column)) . ', ';
         }
@@ -862,46 +862,46 @@ class MySQLSimpleDMLQueryBuilder implements DMLQueryBuilderInterface
     /**
      * Define a UNION or UNION ALL clause of the SQL statement.
      *
-     * @param string $sql_query SQL query reference
-     * @param string $type      Type of UNION operation to perform.
+     * @param string $sqlQuery SQL query reference
+     * @param string $type     Type of UNION operation to perform.
      *
      * @return $this Self reference
      */
-    public function union(string $sql_query, string $type = ''): static
+    public function union(string $sqlQuery, string $type = ''): static
     {
-        $this->builder->union($this->escaper->query_value($sql_query), $type);
+        $this->builder->union($this->escaper->query_value($sqlQuery), $type);
         return $this;
     }
 
     /**
      * Define a with clause.
      *
-     * @param string $alias        The alias of the WITH statement
-     * @param string $sql_query    Sql query reference
-     * @param array  $column_names An optional parameter to give the result columns a name
+     * @param string $alias       The alias of the WITH statement
+     * @param string $sqlQuery    Sql query reference
+     * @param array  $columnNames An optional parameter to give the result columns a name
      *
      * @return $this Self reference
      */
-    public function with($alias, $sql_query, $column_names = NULL): static
+    public function with($alias, $sqlQuery, $columnNames = NULL): static
     {
-        $this->builder->with($alias, $sql_query, $column_names);
+        $this->builder->with($alias, $sqlQuery, $columnNames);
         return $this;
     }
 
     /**
      * Define a recursive WITH clause.
      *
-     * @param string $alias           The alias of the WITH statement
-     * @param string $anchor_query    The initial select statement
-     * @param string $recursive_query The select statement that selects recursively out of the initial query
-     * @param bool   $union_all       True for UNION ALL false for UNION
-     * @param array  $column_names    An optional parameter to give the result columns a name
+     * @param string $alias          The alias of the WITH statement
+     * @param string $anchorQuery    The initial select statement
+     * @param string $recursiveQuery The select statement that selects recursively out of the initial query
+     * @param bool   $unionAll       True for UNION ALL false for UNION
+     * @param array  $columnNames    An optional parameter to give the result columns a name
      *
      * @return $this Self reference
      */
-    public function with_recursive($alias, $anchor_query, $recursive_query, $union_all = FALSE, $column_names = NULL): static
+    public function with_recursive($alias, $anchorQuery, $recursiveQuery, $unionAll = FALSE, $columnNames = NULL): static
     {
-        $this->builder->with_recursive($alias, $anchor_query, $recursive_query, $union_all, $column_names);
+        $this->builder->with_recursive($alias, $anchorQuery, $recursiveQuery, $unionAll, $columnNames);
         return $this;
     }
 
@@ -921,28 +921,28 @@ class MySQLSimpleDMLQueryBuilder implements DMLQueryBuilderInterface
     /**
      * Escape a table reference.
      *
-     * @param string $location_reference A location reference
-     * @param bool   $table              Whether to escape a table or a result_column
+     * @param string $locationReference A location reference
+     * @param bool   $table             Whether to escape a table or a result_column
      *
      * @return string Escaped location reference
      */
-    protected function escape_alias($location_reference, $table = TRUE): string
+    protected function escape_alias($locationReference, $table = TRUE): string
     {
         $method = $table ? 'table' : 'result_column';
 
-        if (strpos($location_reference, ' AS '))
+        if (strpos($locationReference, ' AS '))
         {
-            $parts = explode(' AS ', $location_reference);
+            $parts = explode(' AS ', $locationReference);
             return $this->escaper->{$method}($parts[0], $parts[1]);
         }
-        elseif (strpos($location_reference, ' as '))
+        elseif (strpos($locationReference, ' as '))
         {
-            $parts = explode(' as ', $location_reference);
+            $parts = explode(' as ', $locationReference);
             return $this->escaper->{$method}($parts[0], $parts[1]);
         }
         else
         {
-            return $this->escaper->{$method}($location_reference);
+            return $this->escaper->{$method}($locationReference);
         }
     }
 

--- a/src/Lunr/Gravity/MySQL/Tests/Helpers/AbstractMySQLDatabaseAccessObjectLegacyTest.php
+++ b/src/Lunr/Gravity/MySQL/Tests/Helpers/AbstractMySQLDatabaseAccessObjectLegacyTest.php
@@ -23,6 +23,9 @@ use ReflectionClass;
 /**
  * This class contains setup and tear down methods for DAOs using MySQL access.
  *
+ * phpcs:disable Lunr.NamingConventions.CamelCapsVariableName.NotCamelCaps
+ * phpcs:disable Lunr.NamingConventions.CamelCapsVariableName.MemberVarNotCamelCaps
+ *
  * @deprecated Use `AbstractMySQLDatabaseAccessObjectTest` instead
  */
 abstract class AbstractMySQLDatabaseAccessObjectLegacyTest extends LegacyBaseTest

--- a/src/Lunr/Gravity/MySQL/Tests/Helpers/AbstractMySQLDatabaseAccessObjectTestCase.php
+++ b/src/Lunr/Gravity/MySQL/Tests/Helpers/AbstractMySQLDatabaseAccessObjectTestCase.php
@@ -47,13 +47,13 @@ abstract class AbstractMySQLDatabaseAccessObjectTestCase extends DatabaseAccessO
      * Real instance of the DMLQueryBuilder class
      * @var MySQLDMLQueryBuilder
      */
-    protected $real_builder;
+    protected $realBuilder;
 
     /**
      * Real instance of the SimpleDMLQueryBuilder class
      * @var MySQLSimpleDMLQueryBuilder
      */
-    protected $real_simple_builder;
+    protected $realSimpleBuilder;
 
     /**
      * Mock instance of the QueryEscaper class
@@ -65,7 +65,7 @@ abstract class AbstractMySQLDatabaseAccessObjectTestCase extends DatabaseAccessO
      * Real instance of the QueryEscaper class
      * @var MySQLQueryEscaper
      */
-    protected $real_escaper;
+    protected $realEscaper;
 
     /**
      * Mock instance of the QueryResult class
@@ -78,17 +78,17 @@ abstract class AbstractMySQLDatabaseAccessObjectTestCase extends DatabaseAccessO
      */
     public function setUp(): void
     {
-        $mock_escaper = $this->getMockBuilder('Lunr\Gravity\DatabaseStringEscaperInterface')
-                             ->getMock();
+        $mockEscaper = $this->getMockBuilder('Lunr\Gravity\DatabaseStringEscaperInterface')
+                            ->getMock();
 
-        $mock_escaper->expects($this->any())
-                     ->method('escape_string')
-                     ->willReturnArgument(0);
+        $mockEscaper->expects($this->any())
+                    ->method('escape_string')
+                    ->willReturnArgument(0);
 
-        $this->real_builder = new MySQLDMLQueryBuilder();
-        $this->real_escaper = new MySQLQueryEscaper($mock_escaper);
+        $this->realBuilder = new MySQLDMLQueryBuilder();
+        $this->realEscaper = new MySQLQueryEscaper($mockEscaper);
 
-        $this->real_simple_builder = new MySQLSimpleDMLQueryBuilder($this->real_builder, $this->real_escaper);
+        $this->realSimpleBuilder = new MySQLSimpleDMLQueryBuilder($this->realBuilder, $this->realEscaper);
 
         $this->db = $this->getMockBuilder('Lunr\Gravity\MySQL\MySQLConnection')
                          ->disableOriginalConstructor()
@@ -123,9 +123,9 @@ abstract class AbstractMySQLDatabaseAccessObjectTestCase extends DatabaseAccessO
         unset($this->builder);
         unset($this->escaper);
         unset($this->result);
-        unset($this->real_escaper);
-        unset($this->real_builder);
-        unset($this->real_simple_builder);
+        unset($this->realEscaper);
+        unset($this->realBuilder);
+        unset($this->realSimpleBuilder);
 
         parent::tearDown();
     }

--- a/src/Lunr/Gravity/MySQL/Tests/Helpers/MySQLDatabaseAccessObjectLegacyTest.php
+++ b/src/Lunr/Gravity/MySQL/Tests/Helpers/MySQLDatabaseAccessObjectLegacyTest.php
@@ -22,6 +22,9 @@ use ReflectionClass;
 /**
  * This class contains setup and tear down methods for DAOs using MySQL access.
  *
+ * phpcs:disable Lunr.NamingConventions.CamelCapsVariableName.NotCamelCaps
+ * phpcs:disable Lunr.NamingConventions.CamelCapsVariableName.MemberVarNotCamelCaps
+ *
  * @deprecated Use `MySQLDatabaseAccessObjectTest` instead
  */
 abstract class MySQLDatabaseAccessObjectLegacyTest extends LegacyBaseTest

--- a/src/Lunr/Gravity/MySQL/Tests/Helpers/MySQLDatabaseAccessObjectTestCase.php
+++ b/src/Lunr/Gravity/MySQL/Tests/Helpers/MySQLDatabaseAccessObjectTestCase.php
@@ -46,13 +46,13 @@ abstract class MySQLDatabaseAccessObjectTestCase extends DatabaseAccessObjectBas
      * Real instance of the DMLQueryBuilder class
      * @var MySQLDMLQueryBuilder
      */
-    protected $real_builder;
+    protected $realBuilder;
 
     /**
      * Real instance of the SimpleDMLQueryBuilder class
      * @var MySQLSimpleDMLQueryBuilder
      */
-    protected $real_simple_builder;
+    protected $realSimpleBuilder;
 
     /**
      * Mock instance of the QueryEscaper class
@@ -64,7 +64,7 @@ abstract class MySQLDatabaseAccessObjectTestCase extends DatabaseAccessObjectBas
      * Real instance of the QueryEscaper class
      * @var MySQLQueryEscaper
      */
-    protected $real_escaper;
+    protected $realEscaper;
 
     /**
      * Mock instance of the QueryResult class
@@ -77,17 +77,17 @@ abstract class MySQLDatabaseAccessObjectTestCase extends DatabaseAccessObjectBas
      */
     public function setUp(): void
     {
-        $mock_escaper = $this->getMockBuilder('Lunr\Gravity\DatabaseStringEscaperInterface')
-                             ->getMock();
+        $mockEscaper = $this->getMockBuilder('Lunr\Gravity\DatabaseStringEscaperInterface')
+                            ->getMock();
 
-        $mock_escaper->expects($this->any())
-                     ->method('escape_string')
-                     ->willReturnArgument(0);
+        $mockEscaper->expects($this->any())
+                    ->method('escape_string')
+                    ->willReturnArgument(0);
 
-        $this->real_builder = new MySQLDMLQueryBuilder();
-        $this->real_escaper = new MySQLQueryEscaper($mock_escaper);
+        $this->realBuilder = new MySQLDMLQueryBuilder();
+        $this->realEscaper = new MySQLQueryEscaper($mockEscaper);
 
-        $this->real_simple_builder = new MySQLSimpleDMLQueryBuilder($this->real_builder, $this->real_escaper);
+        $this->realSimpleBuilder = new MySQLSimpleDMLQueryBuilder($this->realBuilder, $this->realEscaper);
 
         $this->db = $this->getMockBuilder('Lunr\Gravity\MySQL\MySQLConnection')
                          ->disableOriginalConstructor()
@@ -122,9 +122,9 @@ abstract class MySQLDatabaseAccessObjectTestCase extends DatabaseAccessObjectBas
         unset($this->builder);
         unset($this->escaper);
         unset($this->result);
-        unset($this->real_escaper);
-        unset($this->real_builder);
-        unset($this->real_simple_builder);
+        unset($this->realEscaper);
+        unset($this->realBuilder);
+        unset($this->realSimpleBuilder);
 
         parent::tearDown();
     }

--- a/src/Lunr/Gravity/MySQL/Tests/MockMySQLiFailedConnection.php
+++ b/src/Lunr/Gravity/MySQL/Tests/MockMySQLiFailedConnection.php
@@ -103,13 +103,13 @@ class MockMySQLiFailedConnection
     /**
      * Fake killing the connection.
      *
-     * @param int $thread_id The thread_id of the connection to kill.
+     * @param int $threadId The thread_id of the connection to kill.
      *
      * @return bool $return TRUE if the thread_id matches the faked one, FALSE otherwise.
      */
-    public function kill($thread_id)
+    public function kill($threadId)
     {
-        if ($thread_id === 666)
+        if ($threadId === 666)
         {
             return TRUE;
         }

--- a/src/Lunr/Gravity/MySQL/Tests/MockMySQLiResult.php
+++ b/src/Lunr/Gravity/MySQL/Tests/MockMySQLiResult.php
@@ -22,16 +22,16 @@ class MockMySQLiResult
      * Instance of a real MySQLi_result class.
      * @var MySQLi_result
      */
-    private $mysqli_result;
+    private $mysqliResult;
 
     /**
      * Constructor.
      *
-     * @param MySQLi_result $mysqli_result Instance of the MySQLi_result class
+     * @param MySQLi_result $mysqliResult Instance of the MySQLi_result class
      */
-    public function __construct($mysqli_result)
+    public function __construct($mysqliResult)
     {
-        $this->mysqli_result = $mysqli_result;
+        $this->mysqliResult = $mysqliResult;
     }
 
     /**
@@ -39,7 +39,7 @@ class MockMySQLiResult
      */
     public function __destruct()
     {
-        unset($this->mysqli_result);
+        unset($this->mysqliResult);
     }
 
     /**
@@ -52,7 +52,7 @@ class MockMySQLiResult
      */
     public function __call($method, $arguments)
     {
-        return call_user_func_array([ $this->mysqli_result, $method ], $arguments);
+        return call_user_func_array([ $this->mysqliResult, $method ], $arguments);
     }
 
     /**
@@ -69,7 +69,7 @@ class MockMySQLiResult
             case 'num_rows':
                 return 5;
             default:
-                return $this->mysqli_result->{$name};
+                return $this->mysqliResult->{$name};
         }
     }
 

--- a/src/Lunr/Gravity/MySQL/Tests/MockMySQLiSuccessfulConnection.php
+++ b/src/Lunr/Gravity/MySQL/Tests/MockMySQLiSuccessfulConnection.php
@@ -103,13 +103,13 @@ class MockMySQLiSuccessfulConnection
     /**
      * Fake killing the connection.
      *
-     * @param int $thread_id The thread_id of the connection to kill.
+     * @param int $threadId The thread_id of the connection to kill.
      *
      * @return bool $return TRUE if the thread_id matches the faked one, FALSE otherwise.
      */
-    public function kill($thread_id)
+    public function kill($threadId)
     {
-        if ($thread_id === 666)
+        if ($threadId === 666)
         {
             return TRUE;
         }

--- a/src/Lunr/Gravity/MySQL/Tests/MockMySQLiSuccessfulWarningConnection.php
+++ b/src/Lunr/Gravity/MySQL/Tests/MockMySQLiSuccessfulWarningConnection.php
@@ -23,9 +23,9 @@ class MockMySQLiSuccessfulWarningConnection extends MockMySQLiSuccessfulConnecti
      */
     public function get_warnings()
     {
-        $mysqli_warning = new MockMySQLiWarning("Data truncated for column 'a' at row 1", 'HY000', 1265, FALSE);
+        $mysqliWarning = new MockMySQLiWarning("Data truncated for column 'a' at row 1", 'HY000', 1265, FALSE);
 
-        return new MockMySQLiWarning("Field 'c' doesn't have a default value", 'HY000', 1364, $mysqli_warning);
+        return new MockMySQLiWarning("Field 'c' doesn't have a default value", 'HY000', 1364, $mysqliWarning);
     }
 
 }

--- a/src/Lunr/Gravity/MySQL/Tests/MockMySQLiWarning.php
+++ b/src/Lunr/Gravity/MySQL/Tests/MockMySQLiWarning.php
@@ -38,22 +38,22 @@ class MockMySQLiWarning
      * The next MockMySQLiWarning or FALSE if no next warning for the next() method
      * @var MockMySQLiWarning|boolean
      */
-    public $next_warning;
+    public $nextWarning;
 
     /**
      * Constructor.
      *
-     * @param string                 $message      Message of the warning
-     * @param string                 $sqlstate     Sqlstate of the warning
-     * @param int                    $errno        Error number of the warning
-     * @param MockMySQLiWarning|bool $next_warning Next warning for the next() method
+     * @param string                 $message     Message of the warning
+     * @param string                 $sqlstate    Sqlstate of the warning
+     * @param int                    $errno       Error number of the warning
+     * @param MockMySQLiWarning|bool $nextWarning Next warning for the next() method
      */
-    public function __construct($message, $sqlstate, $errno, $next_warning)
+    public function __construct($message, $sqlstate, $errno, $nextWarning)
     {
-        $this->message      = $message;
-        $this->sqlstate     = $sqlstate;
-        $this->errno        = $errno;
-        $this->next_warning = $next_warning;
+        $this->message     = $message;
+        $this->sqlstate    = $sqlstate;
+        $this->errno       = $errno;
+        $this->nextWarning = $nextWarning;
     }
 
     /**
@@ -64,15 +64,15 @@ class MockMySQLiWarning
      */
     public function next()
     {
-        if (!$this->next_warning)
+        if (!$this->nextWarning)
         {
             return FALSE;
         }
 
-        $this->message      = $this->next_warning->message;
-        $this->sqlstate     = $this->next_warning->sqlstate;
-        $this->errno        = $this->next_warning->errno;
-        $this->next_warning = $this->next_warning->next_warning;
+        $this->message     = $this->nextWarning->message;
+        $this->sqlstate    = $this->nextWarning->sqlstate;
+        $this->errno       = $this->nextWarning->errno;
+        $this->nextWarning = $this->nextWarning->nextWarning;
 
         return TRUE;
     }

--- a/src/Lunr/Gravity/MySQL/Tests/MockMySQLndFailedConnection.php
+++ b/src/Lunr/Gravity/MySQL/Tests/MockMySQLndFailedConnection.php
@@ -21,20 +21,20 @@ class MockMySQLndFailedConnection extends MySQLndUhConnection
     /**
      * Fake a failed connection to the database server.
      *
-     * @param mysqlnd_connection $connection  Mysqlnd connection handle
-     * @param string             $host        Hostname or IP address
-     * @param string             $user        Username
-     * @param string             $password    Password
-     * @param string             $database    Database
-     * @param int                $port        Port
-     * @param string             $socket      Socket
-     * @param int                $mysql_flags Connection options
+     * @param mysqlnd_connection $connection Mysqlnd connection handle
+     * @param string             $host       Hostname or IP address
+     * @param string             $user       Username
+     * @param string             $password   Password
+     * @param string             $database   Database
+     * @param int                $port       Port
+     * @param string             $socket     Socket
+     * @param int                $mysqlFlags Connection options
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      *
      * @return bool $return Whether the connection was successful or not.
      */
-    public function connect($connection, $host, $user, $password, $database, $port, $socket, $mysql_flags)
+    public function connect($connection, $host, $user, $password, $database, $port, $socket, $mysqlFlags)
     {
         return TRUE;
     }

--- a/src/Lunr/Gravity/MySQL/Tests/MockMySQLndSuccessfulConnection.php
+++ b/src/Lunr/Gravity/MySQL/Tests/MockMySQLndSuccessfulConnection.php
@@ -21,20 +21,20 @@ class MockMySQLndSuccessfulConnection extends MySQLndUhConnection
     /**
      * Fake a successful connection to the database server.
      *
-     * @param mysqlnd_connection $connection  Mysqlnd connection handle
-     * @param string             $host        Hostname or IP address
-     * @param string             $user        Username
-     * @param string             $password    Password
-     * @param string             $database    Database
-     * @param int                $port        Port
-     * @param string             $socket      Socket
-     * @param int                $mysql_flags Connection options
+     * @param mysqlnd_connection $connection Mysqlnd connection handle
+     * @param string             $host       Hostname or IP address
+     * @param string             $user       Username
+     * @param string             $password   Password
+     * @param string             $database   Database
+     * @param int                $port       Port
+     * @param string             $socket     Socket
+     * @param int                $mysqlFlags Connection options
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      *
      * @return bool $return Whether the connection was successful or not.
      */
-    public function connect($connection, $host, $user, $password, $database, $port, $socket, $mysql_flags)
+    public function connect($connection, $host, $user, $password, $database, $port, $socket, $mysqlFlags)
     {
         return TRUE;
     }

--- a/src/Lunr/Gravity/MySQL/Tests/MySQLAccessObjectBaseTest.php
+++ b/src/Lunr/Gravity/MySQL/Tests/MySQLAccessObjectBaseTest.php
@@ -62,11 +62,11 @@ class MySQLAccessObjectBaseTest extends MySQLAccessObjectTestCase
 
         $parent = $this->reflection->getParentClass();
 
-        $parent_property = $parent->getProperty('db');
-        $parent_property->setAccessible(TRUE);
+        $parentProperty = $parent->getProperty('db');
+        $parentProperty->setAccessible(TRUE);
 
         $this->assertNotSame($db, $property->getValue($this->class));
-        $this->assertNotSame($db, $parent_property->getValue($this->class));
+        $this->assertNotSame($db, $parentProperty->getValue($this->class));
 
         $db->expects($this->once())
            ->method('get_query_escaper_object')
@@ -75,7 +75,7 @@ class MySQLAccessObjectBaseTest extends MySQLAccessObjectTestCase
         $this->class->swap_connection($db);
 
         $this->assertSame($db, $property->getValue($this->class));
-        $this->assertSame($db, $parent_property->getValue($this->class));
+        $this->assertSame($db, $parentProperty->getValue($this->class));
     }
 
     /**

--- a/src/Lunr/Gravity/MySQL/Tests/MySQLAsyncQueryResultBaseTest.php
+++ b/src/Lunr/Gravity/MySQL/Tests/MySQLAsyncQueryResultBaseTest.php
@@ -23,7 +23,7 @@ class MySQLAsyncQueryResultBaseTest extends MySQLAsyncQueryResultTestCase
      */
     public function testErrorMessageIsEmpty(): void
     {
-        $property = $this->reflection->getProperty('error_message');
+        $property = $this->reflection->getProperty('errorMessage');
         $property->setAccessible(TRUE);
 
         $this->assertNull($property->getValue($this->class));
@@ -34,7 +34,7 @@ class MySQLAsyncQueryResultBaseTest extends MySQLAsyncQueryResultTestCase
      */
     public function testErrorNumberIsZero(): void
     {
-        $property = $this->reflection->getProperty('error_number');
+        $property = $this->reflection->getProperty('errorNumber');
         $property->setAccessible(TRUE);
 
         $this->assertNull($property->getValue($this->class));
@@ -45,7 +45,7 @@ class MySQLAsyncQueryResultBaseTest extends MySQLAsyncQueryResultTestCase
      */
     public function testInsertIDIsZero(): void
     {
-        $property = $this->reflection->getProperty('insert_id');
+        $property = $this->reflection->getProperty('insertId');
         $property->setAccessible(TRUE);
 
         $this->assertNull($property->getValue($this->class));
@@ -56,7 +56,7 @@ class MySQLAsyncQueryResultBaseTest extends MySQLAsyncQueryResultTestCase
      */
     public function testAffectedRowsIsNumber(): void
     {
-        $property = $this->reflection->getProperty('affected_rows');
+        $property = $this->reflection->getProperty('affectedRows');
         $property->setAccessible(TRUE);
 
         $this->assertNull($property->getValue($this->class));
@@ -67,7 +67,7 @@ class MySQLAsyncQueryResultBaseTest extends MySQLAsyncQueryResultTestCase
      */
     public function testNumberOfRowsIsNumber(): void
     {
-        $property = $this->reflection->getProperty('num_rows');
+        $property = $this->reflection->getProperty('numRows');
         $property->setAccessible(TRUE);
 
         $this->assertNull($property->getValue($this->class));
@@ -297,7 +297,7 @@ class MySQLAsyncQueryResultBaseTest extends MySQLAsyncQueryResultTestCase
 
         $method->invoke($this->class);
 
-        $property = $this->reflection->getProperty('error_message');
+        $property = $this->reflection->getProperty('errorMessage');
         $property->setAccessible(TRUE);
 
         $this->assertEquals('', $property->getValue($this->class));
@@ -324,7 +324,7 @@ class MySQLAsyncQueryResultBaseTest extends MySQLAsyncQueryResultTestCase
 
         $method->invoke($this->class);
 
-        $property = $this->reflection->getProperty('error_number');
+        $property = $this->reflection->getProperty('errorNumber');
         $property->setAccessible(TRUE);
 
         $this->assertEquals(0, $property->getValue($this->class));
@@ -351,7 +351,7 @@ class MySQLAsyncQueryResultBaseTest extends MySQLAsyncQueryResultTestCase
 
         $method->invoke($this->class);
 
-        $property = $this->reflection->getProperty('insert_id');
+        $property = $this->reflection->getProperty('insertId');
         $property->setAccessible(TRUE);
 
         $this->assertEquals(0, $property->getValue($this->class));
@@ -378,7 +378,7 @@ class MySQLAsyncQueryResultBaseTest extends MySQLAsyncQueryResultTestCase
 
         $method->invoke($this->class);
 
-        $property = $this->reflection->getProperty('affected_rows');
+        $property = $this->reflection->getProperty('affectedRows');
         $property->setAccessible(TRUE);
 
         $this->assertEquals(10, $property->getValue($this->class));
@@ -405,7 +405,7 @@ class MySQLAsyncQueryResultBaseTest extends MySQLAsyncQueryResultTestCase
 
         $method->invoke($this->class);
 
-        $property = $this->reflection->getProperty('num_rows');
+        $property = $this->reflection->getProperty('numRows');
         $property->setAccessible(TRUE);
 
         $this->assertEquals(10, $property->getValue($this->class));

--- a/src/Lunr/Gravity/MySQL/Tests/MySQLCanonicalQueryBaseTest.php
+++ b/src/Lunr/Gravity/MySQL/Tests/MySQLCanonicalQueryBaseTest.php
@@ -31,7 +31,7 @@ class MySQLCanonicalQueryBaseTest extends MySQLCanonicalQueryTestCase
      */
     public function testFindPositions(array $data, array $expected): void
     {
-        $property = $this->getReflectionProperty('ignore_positions');
+        $property = $this->getReflectionProperty('ignorePositions');
         $property->setValue($this->class, ($data[1] ?? []));
 
         $method = $this->getReflectionMethod('find_positions');
@@ -86,7 +86,7 @@ class MySQLCanonicalQueryBaseTest extends MySQLCanonicalQueryTestCase
      */
     public function testFindDigit(array $data, $expected): void
     {
-        $property = $this->getReflectionProperty('ignore_positions');
+        $property = $this->getReflectionProperty('ignorePositions');
         $property->setValue($this->class, ($data[1] ?? []));
 
         $method = $this->getReflectionMethod('find_digit');
@@ -107,7 +107,7 @@ class MySQLCanonicalQueryBaseTest extends MySQLCanonicalQueryTestCase
      */
     public function testJumpIgnore(array $data, int $expected): void
     {
-        $property = $this->getReflectionProperty('ignore_positions');
+        $property = $this->getReflectionProperty('ignorePositions');
         $property->setValue($this->class, ($data[1] ?? []));
 
         $method = $this->getReflectionMethod('jump_ignore');
@@ -149,7 +149,7 @@ class MySQLCanonicalQueryBaseTest extends MySQLCanonicalQueryTestCase
      */
     public function testReplaceBetween(array $data, string $expected): void
     {
-        $property = $this->getReflectionProperty('ignore_positions');
+        $property = $this->getReflectionProperty('ignorePositions');
         $property->setValue($this->class, ($data[1] ?? []));
 
         $method = $this->getReflectionMethod('replace_between');
@@ -166,7 +166,7 @@ class MySQLCanonicalQueryBaseTest extends MySQLCanonicalQueryTestCase
      */
     public function testAddIgnorePositions(): void
     {
-        $property = $this->getReflectionProperty('ignore_positions');
+        $property = $this->getReflectionProperty('ignorePositions');
         $property->setValue($this->class, []);
 
         $method = $this->getReflectionMethod('add_ignore_positions');
@@ -209,7 +209,7 @@ class MySQLCanonicalQueryBaseTest extends MySQLCanonicalQueryTestCase
      */
     public function testReplaceNumeric(array $data, string $expected): void
     {
-        $property = $this->getReflectionProperty('ignore_positions');
+        $property = $this->getReflectionProperty('ignorePositions');
         $property->setValue($this->class, ($data[1] ?? []));
 
         $method = $this->getReflectionMethod('replace_numeric');
@@ -291,7 +291,7 @@ class MySQLCanonicalQueryBaseTest extends MySQLCanonicalQueryTestCase
      */
     public function testFindNext(array $data, ?int $expected): void
     {
-        $property = $this->getReflectionProperty('ignore_positions');
+        $property = $this->getReflectionProperty('ignorePositions');
         $property->setValue($this->class, ($data[1] ?? []));
 
         $method = $this->getReflectionMethod('find_next');
@@ -337,7 +337,7 @@ class MySQLCanonicalQueryBaseTest extends MySQLCanonicalQueryTestCase
             $this->markTestSkipped("File \"$expected\" could not be read!");
         }
 
-        $property = $this->getReflectionProperty('ignore_positions');
+        $property = $this->getReflectionProperty('ignorePositions');
         $property->setValue($this->class, []);
 
         $method = $this->getReflectionMethod('collapse_multirows');

--- a/src/Lunr/Gravity/MySQL/Tests/MySQLCanonicalQueryTestCase.php
+++ b/src/Lunr/Gravity/MySQL/Tests/MySQLCanonicalQueryTestCase.php
@@ -50,319 +50,319 @@ abstract class MySQLCanonicalQueryTestCase extends LunrBaseTestCase
     /**
      * Unit Test Data Provider.
      *
-     * @return array $data_provider Array of data values.
+     * @return array $dataProvider Array of data values.
      */
     public function findPositionsDataProvider(): array
     {
-        $data_provider                               = [];
-        $data_provider['first argument not string']  = [[[ '013456789013456789','23','56' ],[]], []];
-        $data_provider['second argument not string'] = [[[ '012346789012346789','23','56' ],[]], [[ 2,17 ]]];
-        $data_provider['both arguments string']      = [[[ '01234567890123456789','23','56' ],[]], [[ 2,6 ],[ 12,16 ]]];
-        $data_provider['both arguments not string']  = [[[ '01234567890123456789','bb','cc' ],[]], []];
-        $data_provider['no second argument']         = [[[ '01234567890123456789','56','' ],[]], [[ 5,6 ],[ 15,16 ]]];
-        $data_provider['no first argument']          = [[[ '01234567890123456789','','56' ],[]], []];
-        $data_provider['single no second arg']       = [[[ '01234567890123456789','5','' ],[]], [[ 5,5 ],[ 15,15 ]]];
-        $data_provider['ignore positions']           = [[[ '01234567890123456789','23','56' ],[[ 1,8 ]]], [[ 12,16 ]]];
+        $dataProvider                               = [];
+        $dataProvider['first argument not string']  = [[[ '013456789013456789','23','56' ],[]], []];
+        $dataProvider['second argument not string'] = [[[ '012346789012346789','23','56' ],[]], [[ 2,17 ]]];
+        $dataProvider['both arguments string']      = [[[ '01234567890123456789','23','56' ],[]], [[ 2,6 ],[ 12,16 ]]];
+        $dataProvider['both arguments not string']  = [[[ '01234567890123456789','bb','cc' ],[]], []];
+        $dataProvider['no second argument']         = [[[ '01234567890123456789','56','' ],[]], [[ 5,6 ],[ 15,16 ]]];
+        $dataProvider['no first argument']          = [[[ '01234567890123456789','','56' ],[]], []];
+        $dataProvider['single no second arg']       = [[[ '01234567890123456789','5','' ],[]], [[ 5,5 ],[ 15,15 ]]];
+        $dataProvider['ignore positions']           = [[[ '01234567890123456789','23','56' ],[[ 1,8 ]]], [[ 12,16 ]]];
 
-        return $data_provider;
+        return $dataProvider;
     }
 
     /**
      * Unit Test Data Provider.
      *
-     * @return array $data_provider Array of data values.
+     * @return array $dataProvider Array of data values.
      */
     public function removeEolBlankSpacesDataProvider(): array
     {
-        $data_provider   = [];
-        $data_provider[] = [ '  SELECT     *   FROM `table`   ','SELECT * FROM `table`' ];
-        $data_provider[] = [ "SELECT * \nFROM `table`",'SELECT * FROM `table`' ];
-        $data_provider[] = [ "SELECT * \r\nFROM `table`",'SELECT * FROM `table`' ];
-        $data_provider[] = [ "SELECT * \rFROM `table`",'SELECT * FROM `table`' ];
+        $dataProvider   = [];
+        $dataProvider[] = [ '  SELECT     *   FROM `table`   ','SELECT * FROM `table`' ];
+        $dataProvider[] = [ "SELECT * \nFROM `table`",'SELECT * FROM `table`' ];
+        $dataProvider[] = [ "SELECT * \r\nFROM `table`",'SELECT * FROM `table`' ];
+        $dataProvider[] = [ "SELECT * \rFROM `table`",'SELECT * FROM `table`' ];
 
-        return $data_provider;
+        return $dataProvider;
     }
 
     /**
      * Unit Test Data Provider.
      *
-     * @return array $data_provider Array of data values.
+     * @return array $dataProvider Array of data values.
      */
     public function isNumericValueDataProvider(): array
     {
-        $data_provider   = [];
-        $data_provider[] = [[ 'value=234567 AND',6 ],[ TRUE,11 ]];
-        $data_provider[] = [[ 'value=0x47 AND',6 ],[ TRUE,9 ]];
-        $data_provider[] = [[ 'value=1.245 AND',6 ],[ TRUE,10 ]];
-        $data_provider[] = [[ 'value=3.82384E-11 AND',6 ],[ TRUE,16 ]];
+        $dataProvider   = [];
+        $dataProvider[] = [[ 'value=234567 AND',6 ],[ TRUE,11 ]];
+        $dataProvider[] = [[ 'value=0x47 AND',6 ],[ TRUE,9 ]];
+        $dataProvider[] = [[ 'value=1.245 AND',6 ],[ TRUE,10 ]];
+        $dataProvider[] = [[ 'value=3.82384E-11 AND',6 ],[ TRUE,16 ]];
 
-        return $data_provider;
+        return $dataProvider;
     }
 
     /**
      * Unit Test Data Provider.
      *
-     * @return array $data_provider Array of data values.
+     * @return array $dataProvider Array of data values.
      */
     public function updatePositionsDataProvider(): array
     {
-        $data_provider   = [];
-        $data_provider[] = [[[[ 3,10 ],[ 25,30 ],[ 40,50 ]],15,5 ],[[ 3,10 ],[ 20,25 ],[ 35,45 ]]];
+        $dataProvider   = [];
+        $dataProvider[] = [[[[ 3,10 ],[ 25,30 ],[ 40,50 ]],15,5 ],[[ 3,10 ],[ 20,25 ],[ 35,45 ]]];
 
-        return $data_provider;
+        return $dataProvider;
     }
 
     /**
      * Unit Test Data Provider.
      *
-     * @return array $data_provider Array of data values.
+     * @return array $dataProvider Array of data values.
      */
     public function findDigitDataProvider(): array
     {
-        $data_provider   = [];
-        $data_provider[] = [[[ 'SELECT * FROM `table1` WHERE `value1`="teste" AND `value2`=12', 22 ],[[ 29,36 ],[ 50,57 ]]],59 ];
-        $data_provider[] = [[[ 'SELECT * FROM `table1` WHERE `value1`="teste" AND `value2`="A"', 22 ],[[ 29,36 ],[ 50,57 ]]],NULL ];
+        $dataProvider   = [];
+        $dataProvider[] = [[[ 'SELECT * FROM `table1` WHERE `value1`="teste" AND `value2`=12', 22 ],[[ 29,36 ],[ 50,57 ]]],59 ];
+        $dataProvider[] = [[[ 'SELECT * FROM `table1` WHERE `value1`="teste" AND `value2`="A"', 22 ],[[ 29,36 ],[ 50,57 ]]],NULL ];
 
-        return $data_provider;
+        return $dataProvider;
     }
 
     /**
      * Unit Test Data Provider.
      *
-     * @return array $data_provider Array of data values.
+     * @return array $dataProvider Array of data values.
      */
     public function jumpIgnoreDataProvider(): array
     {
-        $data_provider   = [];
-        $data_provider[] = [[ 0,[[ 0,10 ],[ 10,100 ],[ 102,110 ]]], 101 ];
+        $dataProvider   = [];
+        $dataProvider[] = [[ 0,[[ 0,10 ],[ 10,100 ],[ 102,110 ]]], 101 ];
 
-        return $data_provider;
+        return $dataProvider;
     }
 
     /**
      * Unit Test Data Provider.
      *
-     * @return array $data_provider Array of data values.
+     * @return array $dataProvider Array of data values.
      */
     public function isNegativeNumberDataProvider(): array
     {
-        $data_provider   = [];
-        $data_provider[] = [[ 'value=123',6 ], FALSE ];
-        $data_provider[] = [[ 'value=-123',7 ], TRUE ];
-        $data_provider[] = [[ 'value=?-123',8 ], FALSE ];
+        $dataProvider   = [];
+        $dataProvider[] = [[ 'value=123',6 ], FALSE ];
+        $dataProvider[] = [[ 'value=-123',7 ], TRUE ];
+        $dataProvider[] = [[ 'value=?-123',8 ], FALSE ];
 
-        return $data_provider;
+        return $dataProvider;
     }
 
     /**
      * Unit Test Data Provider.
      *
-     * @return array $data_provider Array of data values.
+     * @return array $dataProvider Array of data values.
      */
     public function replaceNumericDataProvider(): array
     {
-        $data_provider   = [];
-        $data_provider[] = [[[ 'value=12 and','?' ],NULL ],'value=? and' ];
-        $data_provider[] = [[[ 'value=0x24 and','?' ],NULL ],'value=? and' ];
-        $data_provider[] = [[[ 'value=-12 and','?' ],NULL ],'value=? and' ];
-        $data_provider[] = [[[ 'value=1.24 and','?' ],NULL ],'value=? and' ];
-        $data_provider[] = [[[ 'value=-1.24 and','?' ],NULL ],'value=? and' ];
-        $data_provider[] = [[[ 'value=3.8E-11 and','?' ],NULL ],'value=? and' ];
-        $data_provider[] = [[[ 'value1=123456 and value2=123456 /*! 123 */','?' ],[[ 32,41 ]]],'value1=? and value2=? /*! 123 */' ];
+        $dataProvider   = [];
+        $dataProvider[] = [[[ 'value=12 and','?' ],NULL ],'value=? and' ];
+        $dataProvider[] = [[[ 'value=0x24 and','?' ],NULL ],'value=? and' ];
+        $dataProvider[] = [[[ 'value=-12 and','?' ],NULL ],'value=? and' ];
+        $dataProvider[] = [[[ 'value=1.24 and','?' ],NULL ],'value=? and' ];
+        $dataProvider[] = [[[ 'value=-1.24 and','?' ],NULL ],'value=? and' ];
+        $dataProvider[] = [[[ 'value=3.8E-11 and','?' ],NULL ],'value=? and' ];
+        $dataProvider[] = [[[ 'value1=123456 and value2=123456 /*! 123 */','?' ],[[ 32,41 ]]],'value1=? and value2=? /*! 123 */' ];
 
-        return $data_provider;
+        return $dataProvider;
     }
 
     /**
      * Unit Test Data Provider.
      *
-     * @return array $data_provider Array of data values.
+     * @return array $dataProvider Array of data values.
      */
     public function replaceBetweenDataProvider(): array
     {
-        $data_provider                       = [];
-        $data_provider['replace jump'][0]    = [[ 'SELECT * FROM value1="ignore" AND value2="B"', '"', '"', '"?"',TRUE ],[[ 21,28 ]]];
-        $data_provider['replace jump'][1]    = 'SELECT * FROM value1="ignore" AND value2="?"';
-        $data_provider['replace no jump'][0] = [[ 'SELECT * FROM value1="ignore" AND value2="B"', '"', '"', '"?"',TRUE ],NULL ];
-        $data_provider['replace no jump'][1] = 'SELECT * FROM value1="?" AND value2="?"';
+        $dataProvider                       = [];
+        $dataProvider['replace jump'][0]    = [[ 'SELECT * FROM value1="ignore" AND value2="B"', '"', '"', '"?"',TRUE ],[[ 21,28 ]]];
+        $dataProvider['replace jump'][1]    = 'SELECT * FROM value1="ignore" AND value2="?"';
+        $dataProvider['replace no jump'][0] = [[ 'SELECT * FROM value1="ignore" AND value2="B"', '"', '"', '"?"',TRUE ],NULL ];
+        $dataProvider['replace no jump'][1] = 'SELECT * FROM value1="?" AND value2="?"';
 
-        return $data_provider;
+        return $dataProvider;
     }
 
     /**
      * Unit Test Data Provider.
      *
-     * @return array $data_provider Array of data values.
+     * @return array $dataProvider Array of data values.
      */
     public function canonicalQueryDataProvider(): array
     {
         $path = TEST_STATICS . '/Gravity/Database/MySQL/';
 
-        $data_provider['select']                            = [
+        $dataProvider['select']                            = [
             $path . 'input_select.sql',
             $path . 'output_select.sql',
         ];
-        $data_provider['update']                            = [
+        $dataProvider['update']                            = [
             $path . 'input_update.sql',
             $path . 'output_update.sql',
         ];
-        $data_provider['create']                            = [
+        $dataProvider['create']                            = [
             $path . 'input_create.sql',
             $path . 'output_create.sql',
         ];
-        $data_provider['insert single row']                 = [
+        $dataProvider['insert single row']                 = [
             $path . 'input_insert_single_row.sql',
             $path . 'output_insert_single_row.sql',
         ];
-        $data_provider['insert multi-rows']                 = [
+        $dataProvider['insert multi-rows']                 = [
             $path . 'input_insert_multi_rows.sql',
             $path . 'output_insert_multi_rows.sql',
         ];
-        $data_provider['insert different rows']             = [
+        $dataProvider['insert different rows']             = [
             $path . 'input_insert_different_rows.sql',
             $path . 'output_insert_different_rows.sql',
         ];
-        $data_provider['insert no rows']                    = [
+        $dataProvider['insert no rows']                    = [
             $path . 'input_insert_no_rows.sql',
             $path . 'output_insert_no_rows.sql',
         ];
-        $data_provider['insert value or null multi-rows']   = [
+        $dataProvider['insert value or null multi-rows']   = [
             $path . 'input_insert_value_or_null_multirows.sql',
             $path . 'output_insert_value_or_null_multirows.sql',
         ];
-        $data_provider['insert null diff. case multi-rows'] = [
+        $dataProvider['insert null diff. case multi-rows'] = [
             $path . 'input_insert_null_diff_case_multi_rows.sql',
             $path . 'output_insert_null_diff_case_multi_rows.sql',
         ];
-        $data_provider['replace single row']                = [
+        $dataProvider['replace single row']                = [
             $path . 'input_replace_single_row.sql',
             $path . 'output_replace_single_row.sql',
         ];
-        $data_provider['replace multi-rows']                = [
+        $dataProvider['replace multi-rows']                = [
             $path . 'input_replace_multi_rows.sql',
             $path . 'output_replace_multi_rows.sql',
         ];
-        $data_provider['upserts single row']                = [
+        $dataProvider['upserts single row']                = [
             $path . 'input_upserts_single_row.sql',
             $path . 'output_upserts_single_row.sql',
         ];
-        $data_provider['upserts multi-rows']                = [
+        $dataProvider['upserts multi-rows']                = [
             $path . 'input_upserts_multi_rows.sql',
             $path . 'output_upserts_multi_rows.sql',
         ];
-        $data_provider['upserts function multi-rows']       = [
+        $dataProvider['upserts function multi-rows']       = [
             $path . 'input_upserts_function_multi_rows.sql',
             $path . 'output_upserts_function_multi_rows.sql',
         ];
-        $data_provider['maxscalehints']                     = [
+        $dataProvider['maxscalehints']                     = [
             $path . 'input_maxscalehints.sql',
             $path . 'output_maxscalehints.sql',
         ];
-        $data_provider['cte']                               = [
+        $dataProvider['cte']                               = [
             $path . 'input_cte.sql',
             $path . 'output_cte.sql',
         ];
-        $data_provider['unix_lf']                           = [
+        $dataProvider['unix_lf']                           = [
             $path . 'input_unix_lf.sql',
             $path . 'output_unix_lf.sql',
         ];
-        $data_provider['win_crlf']                          = [
+        $dataProvider['win_crlf']                          = [
             $path . 'input_win_crlf.sql',
             $path . 'output_win_crlf.sql',
         ];
-        $data_provider['mac_cr']                            = [
+        $dataProvider['mac_cr']                            = [
             $path . 'input_mac_cr.sql',
             $path . 'output_mac_cr.sql',
         ];
 
-        return $data_provider;
+        return $dataProvider;
     }
 
     /**
      * Unit Test Data Provider.
      *
-     * @return array $data_provider Array of data values.
+     * @return array $dataProvider Array of data values.
      */
     public function findNextDataProvider(): array
     {
-        $data_provider                      = [];
-        $data_provider['find']              = [[[ 'VALUES (?) , (?)',',',4,NULL ],[]],11 ];
-        $data_provider['find ignore char']  = [[[ ' ,(?),(?)',',',0,[ ' ' ]],[]],1 ];
-        $data_provider['found first index'] = [[[ ',(?),(?)',',',0,[ ' ' ]],[]],0 ];
-        $data_provider['offset']            = [[[ ',(?) ,(?)',',',4,[ ' ' ]],[]],5 ];
-        $data_provider['find not ignore']   = [[[ 'VALUES (?) , (?)',',',4,[ ' ' ]],[]],NULL ];
-        $data_provider['not found']         = [[[ '(?,?) ON ',',',4,NULL ],[]],NULL ];
+        $dataProvider                      = [];
+        $dataProvider['find']              = [[[ 'VALUES (?) , (?)',',',4,NULL ],[]],11 ];
+        $dataProvider['find ignore char']  = [[[ ' ,(?),(?)',',',0,[ ' ' ]],[]],1 ];
+        $dataProvider['found first index'] = [[[ ',(?),(?)',',',0,[ ' ' ]],[]],0 ];
+        $dataProvider['offset']            = [[[ ',(?) ,(?)',',',4,[ ' ' ]],[]],5 ];
+        $dataProvider['find not ignore']   = [[[ 'VALUES (?) , (?)',',',4,[ ' ' ]],[]],NULL ];
+        $dataProvider['not found']         = [[[ '(?,?) ON ',',',4,NULL ],[]],NULL ];
 
-        return $data_provider;
+        return $dataProvider;
     }
 
     /**
      * Unit Test Data Provider.
      *
-     * @return array $data_provider Array of data values.
+     * @return array $dataProvider Array of data values.
      */
     public function getBetweenDelimiterDataProvider(): array
     {
-        $data_provider                      = [];
-        $data_provider['simple']            = [[ ' (?,?,"?") , (?,?,"?") ','(',')',0,[ ' ' ]],[ 1,9 ]];
-        $data_provider['offset']            = [[ 'values (?,?,"?") , (?,?,"?") ','(',')',18,[ ' ' ]],[ 19,27 ]];
-        $data_provider['delimiters inside'] = [[ 'values (COALESCE(?,"?"),?,"?") ','(',')',6,[ ' ' ]],[ 7,29 ]];
-        $data_provider['not found']         = [[ 'values (?,?,"?") , (?,?,"?") ','{','}',6,[ ' ' ]],NULL ];
+        $dataProvider                      = [];
+        $dataProvider['simple']            = [[ ' (?,?,"?") , (?,?,"?") ','(',')',0,[ ' ' ]],[ 1,9 ]];
+        $dataProvider['offset']            = [[ 'values (?,?,"?") , (?,?,"?") ','(',')',18,[ ' ' ]],[ 19,27 ]];
+        $dataProvider['delimiters inside'] = [[ 'values (COALESCE(?,"?"),?,"?") ','(',')',6,[ ' ' ]],[ 7,29 ]];
+        $dataProvider['not found']         = [[ 'values (?,?,"?") , (?,?,"?") ','{','}',6,[ ' ' ]],NULL ];
 
-        return $data_provider;
+        return $dataProvider;
     }
 
     /**
      * Unit Test Data Provider.
      *
-     * @return array $data_provider Array of data values.
+     * @return array $dataProvider Array of data values.
      */
     public function collapseMultiRowInsertsDataProvider(): array
     {
         $path = TEST_STATICS . '/Gravity/Database/MySQL/';
 
-        $data_provider['insert single row']    = [
+        $dataProvider['insert single row']    = [
             $path . 'input_collapse_insert_single_row.sql',
             $path . 'output_collapse_insert_single_row.sql',
         ];
-        $data_provider['insert multi-rows']    = [
+        $dataProvider['insert multi-rows']    = [
             $path . 'input_collapse_insert_multi_rows.sql',
             $path . 'output_collapse_insert_multi_rows.sql',
         ];
-        $data_provider['insert no rows']       = [
+        $dataProvider['insert no rows']       = [
             $path . 'input_collapse_insert_no_rows.sql',
             $path . 'output_collapse_insert_no_rows.sql',
         ];
-        $data_provider['insert different row'] = [
+        $dataProvider['insert different row'] = [
             $path . 'input_collapse_insert_different_row.sql',
             $path . 'output_collapse_insert_different_row.sql',
         ];
-        $data_provider['insert function']      = [
+        $dataProvider['insert function']      = [
             $path . 'input_collapse_insert_function_multi_rows.sql',
             $path . 'output_collapse_insert_function_multi_rows.sql',
         ];
-        $data_provider['replace']              = [
+        $dataProvider['replace']              = [
             $path . 'input_collapse_replace_multi_rows.sql',
             $path . 'output_collapse_replace_multi_rows.sql',
         ];
-        $data_provider['upserts single row']   = [
+        $dataProvider['upserts single row']   = [
             $path . 'input_collapse_upserts_single_row.sql',
             $path . 'output_collapse_upserts_single_row.sql',
         ];
-        $data_provider['upserts multi-rows']   = [
+        $dataProvider['upserts multi-rows']   = [
             $path . 'input_collapse_upserts_multi_rows.sql',
             $path . 'output_collapse_upserts_multi_rows.sql',
         ];
-        $data_provider['upserts function']     = [
+        $dataProvider['upserts function']     = [
             $path . 'input_collapse_upserts_function.sql',
             $path . 'output_collapse_upserts_function.sql',
         ];
-        $data_provider['select']               = [
+        $dataProvider['select']               = [
             $path . 'input_collapse_select.sql',
             $path . 'output_collapse_select.sql',
         ];
 
-        return $data_provider;
+        return $dataProvider;
     }
 
 }

--- a/src/Lunr/Gravity/MySQL/Tests/MySQLConnectionBaseTest.php
+++ b/src/Lunr/Gravity/MySQL/Tests/MySQLConnectionBaseTest.php
@@ -44,7 +44,7 @@ class MySQLConnectionBaseTest extends MySQLConnectionTestCase
      */
     public function testRWHostIsSetCorrectly(): void
     {
-        $this->assertPropertyEquals('rw_host', 'rw_host');
+        $this->assertPropertyEquals('rwHost', 'rw_host');
     }
 
     /**
@@ -52,7 +52,7 @@ class MySQLConnectionBaseTest extends MySQLConnectionTestCase
      */
     public function testROHostIsSetToRWHost(): void
     {
-        $this->assertPropertyEquals('ro_host', 'rw_host');
+        $this->assertPropertyEquals('roHost', 'rw_host');
     }
 
     /**
@@ -100,7 +100,7 @@ class MySQLConnectionBaseTest extends MySQLConnectionTestCase
      */
     public function testQueryHintIsEmpty(): void
     {
-        $this->assertPropertySame('query_hint', '');
+        $this->assertPropertySame('queryHint', '');
     }
 
     /**
@@ -108,7 +108,7 @@ class MySQLConnectionBaseTest extends MySQLConnectionTestCase
      */
     public function testSSLKeyIsSetCorrectly(): void
     {
-        $this->assertPropertyEquals('ssl_key', NULL);
+        $this->assertPropertyEquals('sslKey', NULL);
     }
 
     /**
@@ -116,7 +116,7 @@ class MySQLConnectionBaseTest extends MySQLConnectionTestCase
      */
     public function testSSLCertIsSetCorrectly(): void
     {
-        $this->assertPropertyEquals('ssl_cert', NULL);
+        $this->assertPropertyEquals('sslCert', NULL);
     }
 
     /**
@@ -124,7 +124,7 @@ class MySQLConnectionBaseTest extends MySQLConnectionTestCase
      */
     public function testCACertIsSetCorrectly(): void
     {
-        $this->assertPropertyEquals('ca_cert', NULL);
+        $this->assertPropertyEquals('caCert', NULL);
     }
 
     /**
@@ -132,7 +132,7 @@ class MySQLConnectionBaseTest extends MySQLConnectionTestCase
      */
     public function testCAPathIsSetCorrectly(): void
     {
-        $this->assertPropertyEquals('ca_path', NULL);
+        $this->assertPropertyEquals('caPath', NULL);
     }
 
     /**
@@ -158,6 +158,7 @@ class MySQLConnectionBaseTest extends MySQLConnectionTestCase
     {
         $driver = new MySQLi_Driver();
 
+        // phpcs:ignore Lunr.NamingConventions.CamelCapsVariableName.NotCamelCaps
         $this->assertEquals($driver->report_mode, MYSQLI_REPORT_ERROR);
     }
 

--- a/src/Lunr/Gravity/MySQL/Tests/MySQLConnectionConnectTest.php
+++ b/src/Lunr/Gravity/MySQL/Tests/MySQLConnectionConnectTest.php
@@ -34,7 +34,7 @@ class MySQLConnectionConnectTest extends MySQLConnectionTestCase
 
         $this->setReflectionPropertyValue('mysqli', $mysqli);
         $this->setReflectionPropertyValue('readonly', TRUE);
-        $this->setReflectionPropertyValue('ro_host', 'ro_host');
+        $this->setReflectionPropertyValue('roHost', 'ro_host');
 
         $port   = ini_get('mysqli.default_port');
         $socket = ini_get('mysqli.default_socket');
@@ -105,10 +105,10 @@ class MySQLConnectionConnectTest extends MySQLConnectionTestCase
         $port   = ini_get('mysqli.default_port');
         $socket = ini_get('mysqli.default_socket');
 
-        $this->setReflectionPropertyValue('ssl_key', 'ssl_key');
-        $this->setReflectionPropertyValue('ssl_cert', 'ssl_cert');
-        $this->setReflectionPropertyValue('ca_cert', 'ca_cert');
-        $this->setReflectionPropertyValue('ca_path', 'ca_path');
+        $this->setReflectionPropertyValue('sslKey', 'ssl_key');
+        $this->setReflectionPropertyValue('sslCert', 'ssl_cert');
+        $this->setReflectionPropertyValue('caCert', 'ca_cert');
+        $this->setReflectionPropertyValue('caPath', 'ca_path');
         $this->setReflectionPropertyValue('cipher', 'cipher');
 
         $mysqli->expects($this->once())
@@ -145,10 +145,10 @@ class MySQLConnectionConnectTest extends MySQLConnectionTestCase
         $port   = ini_get('mysqli.default_port');
         $socket = ini_get('mysqli.default_socket');
 
-        $this->setReflectionPropertyValue('ssl_key', 'ssl_key');
-        $this->setReflectionPropertyValue('ssl_cert', 'ssl_cert');
-        $this->setReflectionPropertyValue('ca_cert', 'ca_cert');
-        $this->setReflectionPropertyValue('ca_path', 'ca_path');
+        $this->setReflectionPropertyValue('sslKey', 'ssl_key');
+        $this->setReflectionPropertyValue('sslCert', 'ssl_cert');
+        $this->setReflectionPropertyValue('caCert', 'ca_cert');
+        $this->setReflectionPropertyValue('caPath', 'ca_path');
         $this->setReflectionPropertyValue('cipher', 'cipher');
 
         $mysqli->expects($this->exactly(5))
@@ -223,10 +223,10 @@ class MySQLConnectionConnectTest extends MySQLConnectionTestCase
         $port   = ini_get('mysqli.default_port');
         $socket = ini_get('mysqli.default_socket');
 
-        $this->setReflectionPropertyValue('ssl_key', 'ssl_key');
-        $this->setReflectionPropertyValue('ssl_cert', 'ssl_cert');
-        $this->setReflectionPropertyValue('ca_cert', 'ca_cert');
-        $this->setReflectionPropertyValue('ca_path', 'ca_path');
+        $this->setReflectionPropertyValue('sslKey', 'ssl_key');
+        $this->setReflectionPropertyValue('sslCert', 'ssl_cert');
+        $this->setReflectionPropertyValue('caCert', 'ca_cert');
+        $this->setReflectionPropertyValue('caPath', 'ca_path');
         $this->setReflectionPropertyValue('cipher', 'cipher');
 
         $mysqli->expects($this->exactly(5))
@@ -291,11 +291,11 @@ class MySQLConnectionConnectTest extends MySQLConnectionTestCase
      */
     public function testConnectFailsWhenDriverIsNotMysql(): void
     {
-        $sub_configuration = $this->getMockBuilder('Lunr\Core\Configuration')->getMock();
+        $subConfiguration = $this->getMockBuilder('Lunr\Core\Configuration')->getMock();
 
         $configuration = $this->getMockBuilder('Lunr\Core\Configuration')->getMock();
 
-        $map = [ [ 'db', $sub_configuration ] ];
+        $map = [ [ 'db', $subConfiguration ] ];
 
         $configuration->expects($this->any())
                       ->method('offsetGet')
@@ -309,7 +309,7 @@ class MySQLConnectionConnectTest extends MySQLConnectionTestCase
             [ 'driver', 'not_mysql' ],
         ];
 
-        $sub_configuration->expects($this->any())
+        $subConfiguration->expects($this->any())
                           ->method('offsetGet')
                           ->will($this->returnValueMap($map));
 

--- a/src/Lunr/Gravity/MySQL/Tests/MySQLConnectionEscapeTest.php
+++ b/src/Lunr/Gravity/MySQL/Tests/MySQLConnectionEscapeTest.php
@@ -38,22 +38,22 @@ class MySQLConnectionEscapeTest extends MySQLConnectionTestCase
     /**
      * Test that escape_string() properly escapes the given string.
      *
-     * @param string $string       String to escape
-     * @param string $part_escaped Partially escaped string (as returned by mysqli_escape_string)
-     * @param string $escaped      Expected escaped string
+     * @param string $string      String to escape
+     * @param string $partEscaped Partially escaped string (as returned by mysqli_escape_string)
+     * @param string $escaped     Expected escaped string
      *
      * @dataProvider escapeStringProvider
      * @requires     extension mysqli
      * @covers       Lunr\Gravity\MySQL\MySQLConnection::escape_string
      */
-    public function testEscapeString($string, $part_escaped, $escaped): void
+    public function testEscapeString($string, $partEscaped, $escaped): void
     {
         $property = $this->getReflectionProperty('connected');
         $property->setValue($this->class, TRUE);
 
         $this->mysqli->expects($this->once())
                      ->method('escape_string')
-                     ->will($this->returnValue($part_escaped));
+                     ->will($this->returnValue($partEscaped));
 
         $value = $this->class->escape_string($string);
 

--- a/src/Lunr/Gravity/MySQL/Tests/MySQLConnectionMasterSlaveTest.php
+++ b/src/Lunr/Gravity/MySQL/Tests/MySQLConnectionMasterSlaveTest.php
@@ -27,7 +27,7 @@ class MySQLConnectionMasterSlaveTest extends MySQLConnectionTestCase
     {
         $this->class->run_on_master();
 
-        $this->assertPropertyEquals('query_hint', '/* maxscale route to master */');
+        $this->assertPropertyEquals('queryHint', '/* maxscale route to master */');
     }
 
     /**
@@ -39,7 +39,7 @@ class MySQLConnectionMasterSlaveTest extends MySQLConnectionTestCase
     {
         $this->class->run_on_slave();
 
-        $this->assertPropertyEquals('query_hint', '/* maxscale route to slave */');
+        $this->assertPropertyEquals('queryHint', '/* maxscale route to slave */');
     }
 
     /**
@@ -51,7 +51,7 @@ class MySQLConnectionMasterSlaveTest extends MySQLConnectionTestCase
     {
         $this->class->run_on_master('maxscale');
 
-        $this->assertPropertyEquals('query_hint', '/* maxscale route to master */');
+        $this->assertPropertyEquals('queryHint', '/* maxscale route to master */');
     }
 
     /**
@@ -63,7 +63,7 @@ class MySQLConnectionMasterSlaveTest extends MySQLConnectionTestCase
     {
         $this->class->run_on_slave('maxscale');
 
-        $this->assertPropertyEquals('query_hint', '/* maxscale route to slave */');
+        $this->assertPropertyEquals('queryHint', '/* maxscale route to slave */');
     }
 
     /**

--- a/src/Lunr/Gravity/MySQL/Tests/MySQLConnectionQueryTest.php
+++ b/src/Lunr/Gravity/MySQL/Tests/MySQLConnectionQueryTest.php
@@ -83,7 +83,7 @@ class MySQLConnectionQueryTest extends MySQLConnectionTestCase
 
         $this->setReflectionPropertyValue('mysqli', $mysqli);
         $this->setReflectionPropertyValue('connected', TRUE);
-        $this->setReflectionPropertyValue('query_hint', '/*hint*/');
+        $this->setReflectionPropertyValue('queryHint', '/*hint*/');
 
         $mysqli->expects($this->once())
                ->method('query')
@@ -118,7 +118,7 @@ class MySQLConnectionQueryTest extends MySQLConnectionTestCase
         $this->setReflectionPropertyValue('mysqli', $mysqli);
         $this->setReflectionPropertyValue('connected', TRUE);
 
-        $hint = $this->getReflectionProperty('query_hint');
+        $hint = $this->getReflectionProperty('queryHint');
         $hint->setValue($this->class, '/*hint*/');
 
         $mysqli->expects($this->once())
@@ -211,7 +211,7 @@ class MySQLConnectionQueryTest extends MySQLConnectionTestCase
 
         $this->setReflectionPropertyValue('mysqli', $mysqli);
         $this->setReflectionPropertyValue('connected', TRUE);
-        $this->setReflectionPropertyValue('query_hint', '/*hint*/');
+        $this->setReflectionPropertyValue('queryHint', '/*hint*/');
 
         $mysqli->expects($this->once())
                ->method('query')
@@ -239,7 +239,7 @@ class MySQLConnectionQueryTest extends MySQLConnectionTestCase
         $this->setReflectionPropertyValue('mysqli', $mysqli);
         $this->setReflectionPropertyValue('connected', TRUE);
 
-        $hint = $this->getReflectionProperty('query_hint');
+        $hint = $this->getReflectionProperty('queryHint');
         $hint->setValue($this->class, '/*hint*/');
 
         $mysqli->expects($this->once())

--- a/src/Lunr/Gravity/MySQL/Tests/MySQLConnectionSetTest.php
+++ b/src/Lunr/Gravity/MySQL/Tests/MySQLConnectionSetTest.php
@@ -22,7 +22,7 @@ class MySQLConnectionSetTest extends MySQLConnectionTestCase
      * Sample configuration values.
      * @var array
      */
-    protected array $values_map;
+    protected array $valuesMap;
 
     /**
      * TestCase Constructor.
@@ -31,7 +31,7 @@ class MySQLConnectionSetTest extends MySQLConnectionTestCase
     {
         $this->emptySetUp();
 
-        $this->values_map = [
+        $this->valuesMap = [
             [ 'rw_host', 'rw_host' ],
             [ 'username', 'username' ],
             [ 'password', 'password' ],
@@ -52,17 +52,17 @@ class MySQLConnectionSetTest extends MySQLConnectionTestCase
      */
     public function testSetConfigurationSetsRWHostCorrectly(): void
     {
-        $this->sub_configuration->expects($this->any())
-                                ->method('offsetGet')
-                                ->will($this->returnValueMap($this->values_map));
+        $this->subConfiguration->expects($this->any())
+                               ->method('offsetGet')
+                               ->will($this->returnValueMap($this->valuesMap));
 
-        $property = $this->getReflectionProperty('rw_host');
+        $property = $this->getReflectionProperty('rwHost');
         $property->setValue($this->class, '');
 
         $method = $this->getReflectionMethod('set_configuration');
         $method->invoke($this->class);
 
-        $this->assertPropertyEquals('rw_host', $property->getValue($this->class));
+        $this->assertPropertyEquals('rwHost', $property->getValue($this->class));
     }
 
     /**
@@ -72,9 +72,9 @@ class MySQLConnectionSetTest extends MySQLConnectionTestCase
      */
     public function testSetConfigurationSetsUsernameCorrectly(): void
     {
-        $this->sub_configuration->expects($this->any())
+        $this->subConfiguration->expects($this->any())
                       ->method('offsetGet')
-                      ->will($this->returnValueMap($this->values_map));
+                      ->will($this->returnValueMap($this->valuesMap));
 
         $property = $this->getReflectionProperty('user');
         $property->setValue($this->class, '');
@@ -92,9 +92,9 @@ class MySQLConnectionSetTest extends MySQLConnectionTestCase
      */
     public function testSetConfigurationSetsPasswordCorrectly(): void
     {
-        $this->sub_configuration->expects($this->any())
+        $this->subConfiguration->expects($this->any())
                       ->method('offsetGet')
-                      ->will($this->returnValueMap($this->values_map));
+                      ->will($this->returnValueMap($this->valuesMap));
 
         $property = $this->getReflectionProperty('pwd');
         $property->setValue($this->class, '');
@@ -112,9 +112,9 @@ class MySQLConnectionSetTest extends MySQLConnectionTestCase
      */
     public function testSetConfigurationSetsDatabaseCorrectly(): void
     {
-        $this->sub_configuration->expects($this->any())
+        $this->subConfiguration->expects($this->any())
                       ->method('offsetGet')
-                      ->will($this->returnValueMap($this->values_map));
+                      ->will($this->returnValueMap($this->valuesMap));
 
         $property = $this->getReflectionProperty('db');
         $property->setValue($this->class, '');
@@ -132,11 +132,11 @@ class MySQLConnectionSetTest extends MySQLConnectionTestCase
      */
     public function testSetConfigurationSetsROHostToRWHostIfItIsNotSet(): void
     {
-        $this->sub_configuration->expects($this->any())
+        $this->subConfiguration->expects($this->any())
                       ->method('offsetGet')
-                      ->will($this->returnValueMap($this->values_map));
+                      ->will($this->returnValueMap($this->valuesMap));
 
-        $property = $this->getReflectionProperty('ro_host');
+        $property = $this->getReflectionProperty('roHost');
         $property->setValue($this->class, '');
 
         $method = $this->getReflectionMethod('set_configuration');
@@ -152,13 +152,13 @@ class MySQLConnectionSetTest extends MySQLConnectionTestCase
      */
     public function testSetConfigurationSetsROHostToRWHostIfItIsEmpty(): void
     {
-        $this->values_map[] = [ 'ro_host', '' ];
+        $this->valuesMap[] = [ 'ro_host', '' ];
 
-        $this->sub_configuration->expects($this->any())
+        $this->subConfiguration->expects($this->any())
                       ->method('offsetGet')
-                      ->will($this->returnValueMap($this->values_map));
+                      ->will($this->returnValueMap($this->valuesMap));
 
-        $property = $this->getReflectionProperty('ro_host');
+        $property = $this->getReflectionProperty('roHost');
         $property->setValue($this->class, '');
 
         $method = $this->getReflectionMethod('set_configuration');
@@ -174,17 +174,17 @@ class MySQLConnectionSetTest extends MySQLConnectionTestCase
      */
     public function testSetConfigurationSetsROHostCorrectly(): void
     {
-        $this->values_map[] = [ 'ro_host', 'ro_host' ];
+        $this->valuesMap[] = [ 'ro_host', 'ro_host' ];
 
-        $this->sub_configuration->expects($this->any())
+        $this->subConfiguration->expects($this->any())
                       ->method('offsetGet')
-                      ->will($this->returnValueMap($this->values_map));
+                      ->will($this->returnValueMap($this->valuesMap));
 
-        $this->sub_configuration->expects($this->any())
+        $this->subConfiguration->expects($this->any())
                       ->method('offsetExists')
                       ->will($this->returnValue(TRUE));
 
-        $property = $this->getReflectionProperty('ro_host');
+        $property = $this->getReflectionProperty('roHost');
         $property->setValue($this->class, '');
 
         $method = $this->getReflectionMethod('set_configuration');
@@ -200,9 +200,9 @@ class MySQLConnectionSetTest extends MySQLConnectionTestCase
      */
     public function testSetConfigurationSetsPortToIniValueIfNotSet(): void
     {
-        $this->sub_configuration->expects($this->any())
+        $this->subConfiguration->expects($this->any())
                       ->method('offsetGet')
-                      ->will($this->returnValueMap($this->values_map));
+                      ->will($this->returnValueMap($this->valuesMap));
 
         $this->setReflectionPropertyValue('port', 0);
 
@@ -221,9 +221,9 @@ class MySQLConnectionSetTest extends MySQLConnectionTestCase
     {
         $this->mockFunction('ini_get', fn($arg) => FALSE);
 
-        $this->sub_configuration->expects($this->any())
+        $this->subConfiguration->expects($this->any())
                       ->method('offsetGet')
-                      ->will($this->returnValueMap($this->values_map));
+                      ->will($this->returnValueMap($this->valuesMap));
 
         $this->setReflectionPropertyValue('port', 0);
 
@@ -242,11 +242,11 @@ class MySQLConnectionSetTest extends MySQLConnectionTestCase
      */
     public function testSetConfigurationSetsPortCorrectly(): void
     {
-        $this->values_map[] = [ 'port', 20 ];
+        $this->valuesMap[] = [ 'port', 20 ];
 
-        $this->sub_configuration->expects($this->any())
+        $this->subConfiguration->expects($this->any())
                       ->method('offsetGet')
-                      ->will($this->returnValueMap($this->values_map));
+                      ->will($this->returnValueMap($this->valuesMap));
 
         $this->setReflectionPropertyValue('port', 0);
 
@@ -263,9 +263,9 @@ class MySQLConnectionSetTest extends MySQLConnectionTestCase
      */
     public function testSetConfigurationSetsSocketToIniValueIfNotSet(): void
     {
-        $this->sub_configuration->expects($this->any())
+        $this->subConfiguration->expects($this->any())
                       ->method('offsetGet')
-                      ->will($this->returnValueMap($this->values_map));
+                      ->will($this->returnValueMap($this->valuesMap));
 
         $property = $this->getReflectionProperty('socket');
         $property->setValue($this->class, '');
@@ -283,11 +283,11 @@ class MySQLConnectionSetTest extends MySQLConnectionTestCase
      */
     public function testSetConfigurationSetsSocketCorrectly(): void
     {
-        $this->values_map[] = [ 'socket', 'socket' ];
+        $this->valuesMap[] = [ 'socket', 'socket' ];
 
-        $this->sub_configuration->expects($this->any())
+        $this->subConfiguration->expects($this->any())
                       ->method('offsetGet')
-                      ->will($this->returnValueMap($this->values_map));
+                      ->will($this->returnValueMap($this->valuesMap));
 
         $property = $this->getReflectionProperty('socket');
         $property->setValue($this->class, '');
@@ -305,11 +305,11 @@ class MySQLConnectionSetTest extends MySQLConnectionTestCase
      */
     public function testSetConfigurationSetsSSLKeyCorrectly(): void
     {
-        $this->sub_configuration->expects($this->any())
+        $this->subConfiguration->expects($this->any())
                       ->method('offsetGet')
-                      ->will($this->returnValueMap($this->values_map));
+                      ->will($this->returnValueMap($this->valuesMap));
 
-        $property = $this->getReflectionProperty('ssl_key');
+        $property = $this->getReflectionProperty('sslKey');
         $property->setValue($this->class, '');
 
         $method = $this->getReflectionMethod('set_configuration');
@@ -325,11 +325,11 @@ class MySQLConnectionSetTest extends MySQLConnectionTestCase
      */
     public function testSetConfigurationSetsSSLCertCorrectly(): void
     {
-        $this->sub_configuration->expects($this->any())
+        $this->subConfiguration->expects($this->any())
                       ->method('offsetGet')
-                      ->will($this->returnValueMap($this->values_map));
+                      ->will($this->returnValueMap($this->valuesMap));
 
-        $property = $this->getReflectionProperty('ssl_cert');
+        $property = $this->getReflectionProperty('sslCert');
         $property->setValue($this->class, '');
 
         $method = $this->getReflectionMethod('set_configuration');
@@ -345,11 +345,11 @@ class MySQLConnectionSetTest extends MySQLConnectionTestCase
      */
     public function testSetConfigurationSetsCACertCorrectly(): void
     {
-        $this->sub_configuration->expects($this->any())
+        $this->subConfiguration->expects($this->any())
                       ->method('offsetGet')
-                      ->will($this->returnValueMap($this->values_map));
+                      ->will($this->returnValueMap($this->valuesMap));
 
-        $property = $this->getReflectionProperty('ca_cert');
+        $property = $this->getReflectionProperty('caCert');
         $property->setValue($this->class, '');
 
         $method = $this->getReflectionMethod('set_configuration');
@@ -365,11 +365,11 @@ class MySQLConnectionSetTest extends MySQLConnectionTestCase
      */
     public function testSetConfigurationSetsCAPathCorrectly(): void
     {
-        $this->sub_configuration->expects($this->any())
+        $this->subConfiguration->expects($this->any())
                       ->method('offsetGet')
-                      ->will($this->returnValueMap($this->values_map));
+                      ->will($this->returnValueMap($this->valuesMap));
 
-        $property = $this->getReflectionProperty('ca_path');
+        $property = $this->getReflectionProperty('caPath');
         $property->setValue($this->class, '');
 
         $method = $this->getReflectionMethod('set_configuration');
@@ -385,9 +385,9 @@ class MySQLConnectionSetTest extends MySQLConnectionTestCase
      */
     public function testSetConfigurationSetsCipherCorrectly(): void
     {
-        $this->sub_configuration->expects($this->any())
+        $this->subConfiguration->expects($this->any())
                       ->method('offsetGet')
-                      ->will($this->returnValueMap($this->values_map));
+                      ->will($this->returnValueMap($this->valuesMap));
 
         $property = $this->getReflectionProperty('cipher');
         $property->setValue($this->class, '');

--- a/src/Lunr/Gravity/MySQL/Tests/MySQLConnectionTestCase.php
+++ b/src/Lunr/Gravity/MySQL/Tests/MySQLConnectionTestCase.php
@@ -26,7 +26,7 @@ abstract class MySQLConnectionTestCase extends LunrBaseTestCase
      * Mock instance of the sub Configuration class.
      * @var Configuration
      */
-    protected $sub_configuration;
+    protected $subConfiguration;
 
     /**
      * Mock instance of the Configuration class.
@@ -59,12 +59,12 @@ abstract class MySQLConnectionTestCase extends LunrBaseTestCase
      */
     public function emptySetUp(): void
     {
-        $this->sub_configuration = $this->getMockBuilder('Lunr\Core\Configuration')->getMock();
+        $this->subConfiguration = $this->getMockBuilder('Lunr\Core\Configuration')->getMock();
 
         $this->configuration = $this->getMockBuilder('Lunr\Core\Configuration')->getMock();
 
         $map = [
-            [ 'db', $this->sub_configuration ],
+            [ 'db', $this->subConfiguration ],
         ];
 
         $this->configuration->expects($this->any())
@@ -85,12 +85,12 @@ abstract class MySQLConnectionTestCase extends LunrBaseTestCase
      */
     public function setUp(): void
     {
-        $this->sub_configuration = $this->getMockBuilder('Lunr\Core\Configuration')->getMock();
+        $this->subConfiguration = $this->getMockBuilder('Lunr\Core\Configuration')->getMock();
 
         $this->configuration = $this->getMockBuilder('Lunr\Core\Configuration')->getMock();
 
         $map = [
-            [ 'db', $this->sub_configuration ],
+            [ 'db', $this->subConfiguration ],
         ];
 
         $this->configuration->expects($this->any())
@@ -105,9 +105,9 @@ abstract class MySQLConnectionTestCase extends LunrBaseTestCase
             [ 'driver', 'mysql' ],
         ];
 
-        $this->sub_configuration->expects($this->any())
-                                ->method('offsetGet')
-                                ->will($this->returnValueMap($map));
+        $this->subConfiguration->expects($this->any())
+                               ->method('offsetGet')
+                               ->will($this->returnValueMap($map));
 
         $this->logger = $this->getMockBuilder('Psr\Log\LoggerInterface')->getMock();
 

--- a/src/Lunr/Gravity/MySQL/Tests/MySQLDMLQueryBuilderConditionTest.php
+++ b/src/Lunr/Gravity/MySQL/Tests/MySQLDMLQueryBuilderConditionTest.php
@@ -27,7 +27,7 @@ class MySQLDMLQueryBuilderConditionTest extends MySQLDMLQueryBuilderTestCase
      */
     public function testOnRegexp(): void
     {
-        $property = $this->builder_reflection->getProperty('join');
+        $property = $this->builderReflection->getProperty('join');
         $property->setAccessible(TRUE);
 
         $this->builder->on_regexp('left', 'right');
@@ -43,7 +43,7 @@ class MySQLDMLQueryBuilderConditionTest extends MySQLDMLQueryBuilderTestCase
      */
     public function testOnNotRegexp(): void
     {
-        $property = $this->builder_reflection->getProperty('join');
+        $property = $this->builderReflection->getProperty('join');
         $property->setAccessible(TRUE);
 
         $this->builder->on_regexp('left', 'right', TRUE);
@@ -72,7 +72,7 @@ class MySQLDMLQueryBuilderConditionTest extends MySQLDMLQueryBuilderTestCase
      */
     public function testWhereRegexp(): void
     {
-        $property = $this->builder_reflection->getProperty('where');
+        $property = $this->builderReflection->getProperty('where');
         $property->setAccessible(TRUE);
 
         $this->builder->where_regexp('left', 'right');
@@ -88,7 +88,7 @@ class MySQLDMLQueryBuilderConditionTest extends MySQLDMLQueryBuilderTestCase
      */
     public function testWhereNotRegexp(): void
     {
-        $property = $this->builder_reflection->getProperty('where');
+        $property = $this->builderReflection->getProperty('where');
         $property->setAccessible(TRUE);
 
         $this->builder->where_regexp('left', 'right', TRUE);
@@ -117,7 +117,7 @@ class MySQLDMLQueryBuilderConditionTest extends MySQLDMLQueryBuilderTestCase
      */
     public function testHavingRegexp(): void
     {
-        $property = $this->builder_reflection->getProperty('having');
+        $property = $this->builderReflection->getProperty('having');
         $property->setAccessible(TRUE);
 
         $this->builder->having_regexp('left', 'right');
@@ -133,7 +133,7 @@ class MySQLDMLQueryBuilderConditionTest extends MySQLDMLQueryBuilderTestCase
      */
     public function testHavingNotRegexp(): void
     {
-        $property = $this->builder_reflection->getProperty('having');
+        $property = $this->builderReflection->getProperty('having');
         $property->setAccessible(TRUE);
 
         $this->builder->having_regexp('left', 'right', TRUE);
@@ -161,7 +161,7 @@ class MySQLDMLQueryBuilderConditionTest extends MySQLDMLQueryBuilderTestCase
      */
     public function testSQLXor(): void
     {
-        $property = $this->builder_reflection->getProperty('connector');
+        $property = $this->builderReflection->getProperty('connector');
         $property->setAccessible(TRUE);
 
         $this->builder->sql_xor();
@@ -189,7 +189,7 @@ class MySQLDMLQueryBuilderConditionTest extends MySQLDMLQueryBuilderTestCase
      */
     public function testXor(): void
     {
-        $property = $this->builder_reflection->getProperty('connector');
+        $property = $this->builderReflection->getProperty('connector');
         $property->setAccessible(TRUE);
 
         $this->builder->xor();

--- a/src/Lunr/Gravity/MySQL/Tests/MySQLDMLQueryBuilderDeleteTest.php
+++ b/src/Lunr/Gravity/MySQL/Tests/MySQLDMLQueryBuilderDeleteTest.php
@@ -29,7 +29,7 @@ class MySQLDMLQueryBuilderDeleteTest extends MySQLDMLQueryBuilderTestCase
      */
     public function testDeleteModeSetsStandardCorrectly($mode): void
     {
-        $property = $this->builder_reflection->getProperty('deleteMode');
+        $property = $this->builderReflection->getProperty('deleteMode');
         $property->setAccessible(TRUE);
 
         $this->builder->delete_mode($mode);
@@ -44,7 +44,7 @@ class MySQLDMLQueryBuilderDeleteTest extends MySQLDMLQueryBuilderTestCase
      */
     public function testDeleteModeSetsIgnoresUnknownValues(): void
     {
-        $property = $this->builder_reflection->getProperty('deleteMode');
+        $property = $this->builderReflection->getProperty('deleteMode');
         $property->setAccessible(TRUE);
 
         $this->builder->delete_mode('UNSUPPORTED');
@@ -79,7 +79,7 @@ class MySQLDMLQueryBuilderDeleteTest extends MySQLDMLQueryBuilderTestCase
      */
     public function testDeleteModeCase($value, $expected): void
     {
-        $property = $this->builder_reflection->getProperty('deleteMode');
+        $property = $this->builderReflection->getProperty('deleteMode');
         $property->setAccessible(TRUE);
 
         $this->builder->delete_mode($value);

--- a/src/Lunr/Gravity/MySQL/Tests/MySQLDMLQueryBuilderGroupByTest.php
+++ b/src/Lunr/Gravity/MySQL/Tests/MySQLDMLQueryBuilderGroupByTest.php
@@ -26,7 +26,7 @@ class MySQLDMLQueryBuilderGroupByTest extends MySQLDMLQueryBuilderTestCase
      */
     public function testGroupByWithDefaultOrder(): void
     {
-        $property = $this->builder_reflection->getProperty('groupBy');
+        $property = $this->builderReflection->getProperty('groupBy');
         $property->setAccessible(TRUE);
 
         $this->builder->group_by('group1');
@@ -41,7 +41,7 @@ class MySQLDMLQueryBuilderGroupByTest extends MySQLDMLQueryBuilderTestCase
      */
     public function testGroupByWithCustomOrder(): void
     {
-        $property = $this->builder_reflection->getProperty('groupBy');
+        $property = $this->builderReflection->getProperty('groupBy');
         $property->setAccessible(TRUE);
 
         $this->builder->group_by('group1', FALSE);

--- a/src/Lunr/Gravity/MySQL/Tests/MySQLDMLQueryBuilderInsertTest.php
+++ b/src/Lunr/Gravity/MySQL/Tests/MySQLDMLQueryBuilderInsertTest.php
@@ -55,7 +55,7 @@ class MySQLDMLQueryBuilderInsertTest extends MySQLDMLQueryBuilderTestCase
      */
     public function testInsertModeSetsStandardCorrectly($mode): void
     {
-        $property = $this->builder_reflection->getProperty('insertMode');
+        $property = $this->builderReflection->getProperty('insertMode');
         $property->setAccessible(TRUE);
 
         $this->builder->insert_mode($mode);
@@ -70,7 +70,7 @@ class MySQLDMLQueryBuilderInsertTest extends MySQLDMLQueryBuilderTestCase
      */
     public function testInsertModeSetsIgnoresUnknownValues(): void
     {
-        $property = $this->builder_reflection->getProperty('insertMode');
+        $property = $this->builderReflection->getProperty('insertMode');
         $property->setAccessible(TRUE);
 
         $this->builder->insert_mode('UNSUPPORTED');
@@ -92,7 +92,7 @@ class MySQLDMLQueryBuilderInsertTest extends MySQLDMLQueryBuilderTestCase
      */
     public function testInsertModeCase($value, $expected): void
     {
-        $property = $this->builder_reflection->getProperty('insertMode');
+        $property = $this->builderReflection->getProperty('insertMode');
         $property->setAccessible(TRUE);
 
         $this->builder->insert_mode($value);
@@ -107,7 +107,7 @@ class MySQLDMLQueryBuilderInsertTest extends MySQLDMLQueryBuilderTestCase
      */
     public function testOnDuplicateKeyUpdate()
     {
-        $property = $this->builder_reflection->getProperty('upsert');
+        $property = $this->builderReflection->getProperty('upsert');
         $property->setAccessible(TRUE);
 
         $return = $this->builder->on_duplicate_key_update('col=col+1');

--- a/src/Lunr/Gravity/MySQL/Tests/MySQLDMLQueryBuilderSelectTest.php
+++ b/src/Lunr/Gravity/MySQL/Tests/MySQLDMLQueryBuilderSelectTest.php
@@ -29,7 +29,7 @@ class MySQLDMLQueryBuilderSelectTest extends MySQLDMLQueryBuilderTestCase
      */
     public function testSelectModeSetsDuplicatesCorrectly($mode): void
     {
-        $property = $this->builder_reflection->getProperty('selectMode');
+        $property = $this->builderReflection->getProperty('selectMode');
         $property->setAccessible(TRUE);
 
         $this->builder->select_mode($mode);
@@ -49,7 +49,7 @@ class MySQLDMLQueryBuilderSelectTest extends MySQLDMLQueryBuilderTestCase
      */
     public function testSelectModeSetsCacheCorrectly($mode): void
     {
-        $property = $this->builder_reflection->getProperty('selectMode');
+        $property = $this->builderReflection->getProperty('selectMode');
         $property->setAccessible(TRUE);
 
         $this->builder->select_mode($mode);
@@ -69,7 +69,7 @@ class MySQLDMLQueryBuilderSelectTest extends MySQLDMLQueryBuilderTestCase
      */
     public function testSelectModeSetsStandardCorrectly($mode): void
     {
-        $property = $this->builder_reflection->getProperty('selectMode');
+        $property = $this->builderReflection->getProperty('selectMode');
         $property->setAccessible(TRUE);
 
         $this->builder->select_mode($mode);
@@ -84,7 +84,7 @@ class MySQLDMLQueryBuilderSelectTest extends MySQLDMLQueryBuilderTestCase
      */
     public function testSelectModeSetsIgnoresUnknownValues(): void
     {
-        $property = $this->builder_reflection->getProperty('selectMode');
+        $property = $this->builderReflection->getProperty('selectMode');
         $property->setAccessible(TRUE);
 
         $this->builder->select_mode('UNSUPPORTED');
@@ -105,7 +105,7 @@ class MySQLDMLQueryBuilderSelectTest extends MySQLDMLQueryBuilderTestCase
      */
     public function testLockModeSetsStandardCorrectly($mode): void
     {
-        $property = $this->builder_reflection->getProperty('lockMode');
+        $property = $this->builderReflection->getProperty('lockMode');
         $property->setAccessible(TRUE);
 
         $this->builder->lock_mode($mode);
@@ -120,7 +120,7 @@ class MySQLDMLQueryBuilderSelectTest extends MySQLDMLQueryBuilderTestCase
      */
     public function testLockModeSetsIgnoresUnknownValues(): void
     {
-        $property = $this->builder_reflection->getProperty('lockMode');
+        $property = $this->builderReflection->getProperty('lockMode');
         $property->setAccessible(TRUE);
 
         $this->builder->lock_mode('UNSUPPORTED');
@@ -138,7 +138,7 @@ class MySQLDMLQueryBuilderSelectTest extends MySQLDMLQueryBuilderTestCase
      */
     public function testSelectModeAllowsOnlyOneDuplicateStatement(): void
     {
-        $property = $this->builder_reflection->getProperty('selectMode');
+        $property = $this->builderReflection->getProperty('selectMode');
         $property->setAccessible(TRUE);
 
         $this->builder->select_mode('ALL');
@@ -158,7 +158,7 @@ class MySQLDMLQueryBuilderSelectTest extends MySQLDMLQueryBuilderTestCase
      */
     public function testSelectModeAllowsOnlyOneCacheStatement(): void
     {
-        $property = $this->builder_reflection->getProperty('selectMode');
+        $property = $this->builderReflection->getProperty('selectMode');
         $property->setAccessible(TRUE);
 
         $this->builder->select_mode('SQL_NO_CACHE');

--- a/src/Lunr/Gravity/MySQL/Tests/MySQLDMLQueryBuilderTestCase.php
+++ b/src/Lunr/Gravity/MySQL/Tests/MySQLDMLQueryBuilderTestCase.php
@@ -33,7 +33,7 @@ abstract class MySQLDMLQueryBuilderTestCase extends TestCase
      * Reflection instance of the MySQLDMLQueryBuilder class.
      * @var ReflectionClass
      */
-    protected $builder_reflection;
+    protected $builderReflection;
 
     /**
      * TestCase Constructor.
@@ -41,8 +41,8 @@ abstract class MySQLDMLQueryBuilderTestCase extends TestCase
     public function setUp(): void
     {
 
-        $this->builder            = new MySQLDMLQueryBuilder();
-        $this->builder_reflection = new ReflectionClass('Lunr\Gravity\MySQL\MySQLDMLQueryBuilder');
+        $this->builder           = new MySQLDMLQueryBuilder();
+        $this->builderReflection = new ReflectionClass('Lunr\Gravity\MySQL\MySQLDMLQueryBuilder');
     }
 
     /**
@@ -51,7 +51,7 @@ abstract class MySQLDMLQueryBuilderTestCase extends TestCase
     public function tearDown(): void
     {
         unset($this->builder);
-        unset($this->builder_reflection);
+        unset($this->builderReflection);
     }
 
     /**

--- a/src/Lunr/Gravity/MySQL/Tests/MySQLDMLQueryBuilderUpdateTest.php
+++ b/src/Lunr/Gravity/MySQL/Tests/MySQLDMLQueryBuilderUpdateTest.php
@@ -29,7 +29,7 @@ class MySQLDMLQueryBuilderUpdateTest extends MySQLDMLQueryBuilderTestCase
      */
     public function testUpdateModeSetsStandardCorrectly($mode): void
     {
-        $property = $this->builder_reflection->getProperty('updateMode');
+        $property = $this->builderReflection->getProperty('updateMode');
         $property->setAccessible(TRUE);
 
         $this->builder->update_mode($mode);
@@ -45,7 +45,7 @@ class MySQLDMLQueryBuilderUpdateTest extends MySQLDMLQueryBuilderTestCase
      */
     public function testUpdateModeIgnoresUnknownValues(): void
     {
-        $property = $this->builder_reflection->getProperty('updateMode');
+        $property = $this->builderReflection->getProperty('updateMode');
         $property->setAccessible(TRUE);
 
         $this->builder->update_mode('UNSUPPORTED');

--- a/src/Lunr/Gravity/MySQL/Tests/MySQLQueryResultBaseTest.php
+++ b/src/Lunr/Gravity/MySQL/Tests/MySQLQueryResultBaseTest.php
@@ -35,7 +35,7 @@ class MySQLQueryResultBaseTest extends MySQLQueryResultTestCase
      */
     public function testErrorMessageIsEmpty(): void
     {
-        $this->assertPropertyEquals('error_message', '');
+        $this->assertPropertyEquals('errorMessage', '');
     }
 
     /**
@@ -43,7 +43,7 @@ class MySQLQueryResultBaseTest extends MySQLQueryResultTestCase
      */
     public function testErrorNumberIsZero(): void
     {
-        $this->assertPropertyEquals('error_number', 0);
+        $this->assertPropertyEquals('errorNumber', 0);
     }
 
     /**
@@ -59,7 +59,7 @@ class MySQLQueryResultBaseTest extends MySQLQueryResultTestCase
      */
     public function testInsertIDIsZero(): void
     {
-        $this->assertPropertyEquals('insert_id', 0);
+        $this->assertPropertyEquals('insertId', 0);
     }
 
     /**
@@ -67,7 +67,7 @@ class MySQLQueryResultBaseTest extends MySQLQueryResultTestCase
      */
     public function testAffectedRowsIsNumber(): void
     {
-        $this->assertPropertyEquals('affected_rows', 10);
+        $this->assertPropertyEquals('affectedRows', 10);
     }
 
     /**
@@ -75,7 +75,7 @@ class MySQLQueryResultBaseTest extends MySQLQueryResultTestCase
      */
     public function testNumberOfRowsIsNumber(): void
     {
-        $this->assertPropertyEquals('num_rows', 10);
+        $this->assertPropertyEquals('numRows', 10);
     }
 
     /**
@@ -93,7 +93,7 @@ class MySQLQueryResultBaseTest extends MySQLQueryResultTestCase
      */
     public function testAffectedRowsReturnsNumber(): void
     {
-        $this->setReflectionPropertyValue('affected_rows', 10);
+        $this->setReflectionPropertyValue('affectedRows', 10);
 
         $value = $this->class->affected_rows();
         $this->assertIsInt($value);
@@ -107,7 +107,7 @@ class MySQLQueryResultBaseTest extends MySQLQueryResultTestCase
      */
     public function testNumberOfRowsReturnsNumber(): void
     {
-        $this->setReflectionPropertyValue('num_rows', 10);
+        $this->setReflectionPropertyValue('numRows', 10);
 
         $value = $this->class->number_of_rows();
         $this->assertIsInt($value);
@@ -121,7 +121,7 @@ class MySQLQueryResultBaseTest extends MySQLQueryResultTestCase
      */
     public function testErrorMessageReturnsString(): void
     {
-        $this->setReflectionPropertyValue('error_message', '');
+        $this->setReflectionPropertyValue('errorMessage', '');
 
         $value = $this->class->error_message();
         $this->assertIsString($value);
@@ -135,7 +135,7 @@ class MySQLQueryResultBaseTest extends MySQLQueryResultTestCase
      */
     public function testErrorNumberReturnsNumber(): void
     {
-        $this->setReflectionPropertyValue('error_number', 0);
+        $this->setReflectionPropertyValue('errorNumber', 0);
 
         $value = $this->class->error_number();
         $this->assertIsInt($value);
@@ -149,7 +149,7 @@ class MySQLQueryResultBaseTest extends MySQLQueryResultTestCase
      */
     public function testInsertIDReturnsNumber(): void
     {
-        $this->setReflectionPropertyValue('insert_id', 0);
+        $this->setReflectionPropertyValue('insertId', 0);
 
         $value = $this->class->insert_id();
         $this->assertIsInt($value);
@@ -194,7 +194,7 @@ class MySQLQueryResultBaseTest extends MySQLQueryResultTestCase
         $this->assertIsString($value);
         $this->assertEquals('SELECT * FROM table1 WHERE value="?"', $value);
 
-        $value = $this->getReflectionPropertyValue('canonical_query');
+        $value = $this->getReflectionPropertyValue('canonicalQuery');
         $this->assertIsString($value);
         $this->assertEquals('SELECT * FROM table1 WHERE value="?"', $value);
     }
@@ -206,8 +206,8 @@ class MySQLQueryResultBaseTest extends MySQLQueryResultTestCase
      */
     public function testCachedCanonicalQuery(): void
     {
-        $this->assertPropertyUnset('canonical_query');
-        $this->setReflectionPropertyValue('canonical_query', 'SELECT * FROM table2 WHERE value=?');
+        $this->assertPropertyUnset('canonicalQuery');
+        $this->setReflectionPropertyValue('canonicalQuery', 'SELECT * FROM table2 WHERE value=?');
         $value = $this->class->canonical_query();
         $this->assertIsString($value);
         $this->assertEquals('SELECT * FROM table2 WHERE value=?', $value);

--- a/src/Lunr/Gravity/MySQL/Tests/MySQLQueryResultFailedTest.php
+++ b/src/Lunr/Gravity/MySQL/Tests/MySQLQueryResultFailedTest.php
@@ -70,7 +70,7 @@ class MySQLQueryResultFailedTest extends MySQLQueryResultTestCase
      */
     public function testErrorMessageIsString(): void
     {
-        $this->assertPropertyEquals('error_message', 'bad');
+        $this->assertPropertyEquals('errorMessage', 'bad');
     }
 
     /**
@@ -78,7 +78,7 @@ class MySQLQueryResultFailedTest extends MySQLQueryResultTestCase
      */
     public function testErrorNumberIsNumber(): void
     {
-        $this->assertPropertyEquals('error_number', 666);
+        $this->assertPropertyEquals('errorNumber', 666);
     }
 
     /**
@@ -86,7 +86,7 @@ class MySQLQueryResultFailedTest extends MySQLQueryResultTestCase
      */
     public function testInsertIDIsZero(): void
     {
-        $this->assertPropertyEquals('insert_id', 0);
+        $this->assertPropertyEquals('insertId', 0);
     }
 
     /**
@@ -94,7 +94,7 @@ class MySQLQueryResultFailedTest extends MySQLQueryResultTestCase
      */
     public function testAffectedRowsIsNumber(): void
     {
-        $this->assertPropertyEquals('affected_rows', 10);
+        $this->assertPropertyEquals('affectedRows', 10);
     }
 
     /**
@@ -102,7 +102,7 @@ class MySQLQueryResultFailedTest extends MySQLQueryResultTestCase
      */
     public function testNumberOfRowsIsNumber(): void
     {
-        $this->assertPropertyEquals('num_rows', 10);
+        $this->assertPropertyEquals('numRows', 10);
     }
 
     /**
@@ -112,7 +112,7 @@ class MySQLQueryResultFailedTest extends MySQLQueryResultTestCase
      */
     public function testNumberOfRowsReturnsNumber(): void
     {
-        $this->setReflectionPropertyValue('num_rows', 666);
+        $this->setReflectionPropertyValue('numRows', 666);
 
         $value = $this->class->number_of_rows();
         $this->assertIsInt($value);
@@ -166,7 +166,7 @@ class MySQLQueryResultFailedTest extends MySQLQueryResultTestCase
      */
     public function testHasDeadlockReturnsTrue(): void
     {
-        $this->setReflectionPropertyValue('error_number', 1213);
+        $this->setReflectionPropertyValue('errorNumber', 1213);
 
         $this->assertTrue($this->class->has_deadlock());
     }
@@ -178,7 +178,7 @@ class MySQLQueryResultFailedTest extends MySQLQueryResultTestCase
      */
     public function testHasDeadlockReturnsFalse(): void
     {
-        $this->setReflectionPropertyValue('error_number', 999);
+        $this->setReflectionPropertyValue('errorNumber', 999);
 
         $this->assertFalse($this->class->has_deadlock());
     }
@@ -190,7 +190,7 @@ class MySQLQueryResultFailedTest extends MySQLQueryResultTestCase
      */
     public function testLockTimeoutReturnsTrue(): void
     {
-        $this->setReflectionPropertyValue('error_number', 1205);
+        $this->setReflectionPropertyValue('errorNumber', 1205);
 
         $this->assertTrue($this->class->has_lock_timeout());
     }
@@ -202,7 +202,7 @@ class MySQLQueryResultFailedTest extends MySQLQueryResultTestCase
      */
     public function testLockTimeoutReturnsFalse(): void
     {
-        $this->setReflectionPropertyValue('error_number', 999);
+        $this->setReflectionPropertyValue('errorNumber', 999);
 
         $this->assertFalse($this->class->has_lock_timeout());
     }

--- a/src/Lunr/Gravity/MySQL/Tests/MySQLQueryResultFreeTest.php
+++ b/src/Lunr/Gravity/MySQL/Tests/MySQLQueryResultFreeTest.php
@@ -39,7 +39,7 @@ class MySQLQueryResultFreeTest extends MySQLQueryResultTestCase
      */
     public function testFreeResultFreesIfFreedIsFalse(): void
     {
-        $this->query_result->expects($this->once())
+        $this->queryResult->expects($this->once())
                     ->method('free');
 
         $method = $this->getReflectionMethod('free_result');
@@ -56,7 +56,7 @@ class MySQLQueryResultFreeTest extends MySQLQueryResultTestCase
     {
         $this->setReflectionPropertyValue('freed', TRUE);
 
-        $this->query_result->expects($this->never())
+        $this->queryResult->expects($this->never())
                     ->method('free');
 
         $method = $this->getReflectionMethod('free_result');
@@ -73,8 +73,8 @@ class MySQLQueryResultFreeTest extends MySQLQueryResultTestCase
      */
     public function testResultArrayFreesDataIfFreedIsFalse(): void
     {
-        $this->query_result->expects($this->once())
-                           ->method('free');
+        $this->queryResult->expects($this->once())
+                          ->method('free');
 
         $this->class->result_array();
     }
@@ -88,8 +88,8 @@ class MySQLQueryResultFreeTest extends MySQLQueryResultTestCase
     {
         $this->setReflectionPropertyValue('freed', TRUE);
 
-        $this->query_result->expects($this->never())
-                           ->method('free');
+        $this->queryResult->expects($this->never())
+                          ->method('free');
 
         $this->class->result_array();
     }
@@ -101,8 +101,8 @@ class MySQLQueryResultFreeTest extends MySQLQueryResultTestCase
      */
     public function testResultRowFreesDataIfFreedIsFalse(): void
     {
-        $this->query_result->expects($this->once())
-                           ->method('free');
+        $this->queryResult->expects($this->once())
+                          ->method('free');
 
         $this->class->result_row();
     }
@@ -116,8 +116,8 @@ class MySQLQueryResultFreeTest extends MySQLQueryResultTestCase
     {
         $this->setReflectionPropertyValue('freed', TRUE);
 
-        $this->query_result->expects($this->never())
-                           ->method('free');
+        $this->queryResult->expects($this->never())
+                          ->method('free');
 
         $this->class->result_row();
     }
@@ -129,8 +129,8 @@ class MySQLQueryResultFreeTest extends MySQLQueryResultTestCase
      */
     public function testResultColumnFreesDataIfFreedIsFalse(): void
     {
-        $this->query_result->expects($this->once())
-                           ->method('free');
+        $this->queryResult->expects($this->once())
+                          ->method('free');
 
         $this->class->result_column('col');
     }
@@ -144,8 +144,8 @@ class MySQLQueryResultFreeTest extends MySQLQueryResultTestCase
     {
         $this->setReflectionPropertyValue('freed', TRUE);
 
-        $this->query_result->expects($this->never())
-                           ->method('free');
+        $this->queryResult->expects($this->never())
+                          ->method('free');
 
         $this->class->result_column('col');
     }
@@ -157,8 +157,8 @@ class MySQLQueryResultFreeTest extends MySQLQueryResultTestCase
      */
     public function testResultCellFreesDataIfFreedIsFalse(): void
     {
-        $this->query_result->expects($this->once())
-                           ->method('free');
+        $this->queryResult->expects($this->once())
+                          ->method('free');
 
         $this->class->result_cell('cell');
     }
@@ -172,8 +172,8 @@ class MySQLQueryResultFreeTest extends MySQLQueryResultTestCase
     {
         $this->setReflectionPropertyValue('freed', TRUE);
 
-        $this->query_result->expects($this->never())
-                           ->method('free');
+        $this->queryResult->expects($this->never())
+                          ->method('free');
 
         $this->class->result_cell('cell');
     }

--- a/src/Lunr/Gravity/MySQL/Tests/MySQLQueryResultResultTest.php
+++ b/src/Lunr/Gravity/MySQL/Tests/MySQLQueryResultResultTest.php
@@ -72,7 +72,7 @@ class MySQLQueryResultResultTest extends MySQLQueryResultTestCase
      */
     public function testNumberOfRowsReturnsNumber(): void
     {
-        $this->setReflectionPropertyValue('num_rows', 5);
+        $this->setReflectionPropertyValue('numRows', 5);
 
         $value = $this->class->number_of_rows();
         $this->assertIsInt($value);
@@ -98,10 +98,10 @@ class MySQLQueryResultResultTest extends MySQLQueryResultTestCase
             ],
         ];
 
-        $this->query_result->expects($this->once())
-                           ->method('fetch_all')
-                           ->with(MYSQLI_ASSOC)
-                           ->willReturn($result);
+        $this->queryResult->expects($this->once())
+                          ->method('fetch_all')
+                          ->with(MYSQLI_ASSOC)
+                          ->willReturn($result);
 
         $value = $this->class->result_array();
 
@@ -126,10 +126,10 @@ class MySQLQueryResultResultTest extends MySQLQueryResultTestCase
             ],
         ];
 
-        $this->query_result->expects($this->once())
-                           ->method('fetch_all')
-                           ->with(MYSQLI_NUM)
-                           ->willReturn($result);
+        $this->queryResult->expects($this->once())
+                          ->method('fetch_all')
+                          ->with(MYSQLI_NUM)
+                          ->willReturn($result);
 
         $value = $this->class->result_array(FALSE);
 
@@ -146,9 +146,9 @@ class MySQLQueryResultResultTest extends MySQLQueryResultTestCase
     public function testResultRowReturnsArray(): void
     {
         $result = [ 'col1' => 'val1', 'col2' => 'val2' ];
-        $this->query_result->expects($this->once())
-                           ->method('fetch_assoc')
-                           ->will($this->returnValue($result));
+        $this->queryResult->expects($this->once())
+                          ->method('fetch_assoc')
+                          ->will($this->returnValue($result));
 
         $value = $this->class->result_row();
 
@@ -164,13 +164,13 @@ class MySQLQueryResultResultTest extends MySQLQueryResultTestCase
      */
     public function testResultColumnReturnsArray(): void
     {
-        $this->query_result->expects($this->exactly(3))
-                           ->method('fetch_assoc')
-                           ->willReturnOnConsecutiveCalls(
-                               [ 'col1' => 'val1', 'col2' => 'val2' ],
-                               [ 'col1' => 'val3', 'col2' => 'val4' ],
-                               NULL
-                           );
+        $this->queryResult->expects($this->exactly(3))
+                          ->method('fetch_assoc')
+                          ->willReturnOnConsecutiveCalls(
+                              [ 'col1' => 'val1', 'col2' => 'val2' ],
+                              [ 'col1' => 'val3', 'col2' => 'val4' ],
+                              NULL
+                          );
 
         $value = $this->class->result_column('col1');
 
@@ -186,9 +186,9 @@ class MySQLQueryResultResultTest extends MySQLQueryResultTestCase
      */
     public function testResultCellReturnsValue(): void
     {
-        $this->query_result->expects($this->once())
-                           ->method('fetch_assoc')
-                           ->will($this->returnValue([ 'cell' => 'value' ]));
+        $this->queryResult->expects($this->once())
+                          ->method('fetch_assoc')
+                          ->will($this->returnValue([ 'cell' => 'value' ]));
 
         $this->assertEquals('value', $this->class->result_cell('cell'));
     }
@@ -201,9 +201,9 @@ class MySQLQueryResultResultTest extends MySQLQueryResultTestCase
      */
     public function testResultCellReturnsNullIfColumnDoesNotExist(): void
     {
-        $this->query_result->expects($this->once())
-                           ->method('fetch_assoc')
-                           ->will($this->returnValue([ 'cell' => 'value' ]));
+        $this->queryResult->expects($this->once())
+                          ->method('fetch_assoc')
+                          ->will($this->returnValue([ 'cell' => 'value' ]));
 
         $this->assertNull($this->class->result_cell('cell1'));
     }

--- a/src/Lunr/Gravity/MySQL/Tests/MySQLQueryResultSuccessTest.php
+++ b/src/Lunr/Gravity/MySQL/Tests/MySQLQueryResultSuccessTest.php
@@ -72,7 +72,7 @@ class MySQLQueryResultSuccessTest extends MySQLQueryResultTestCase
      */
     public function testNumberOfRowsReturnsNumber(): void
     {
-        $this->setReflectionPropertyValue('num_rows', 10);
+        $this->setReflectionPropertyValue('numRows', 10);
 
         $value = $this->class->number_of_rows();
         $this->assertIsInt($value);

--- a/src/Lunr/Gravity/MySQL/Tests/MySQLQueryResultTestCase.php
+++ b/src/Lunr/Gravity/MySQL/Tests/MySQLQueryResultTestCase.php
@@ -27,7 +27,7 @@ abstract class MySQLQueryResultTestCase extends LunrBaseTestCase
      * Query result
      * @var mixed
      */
-    protected $query_result;
+    protected $queryResult;
 
     /**
      * Instance of the mysqli class.
@@ -56,13 +56,13 @@ abstract class MySQLQueryResultTestCase extends LunrBaseTestCase
     {
         $this->mysqli = new MockMySQLiSuccessfulConnection($this->getMockBuilder('\mysqli')->getMock());
 
-        $this->query_result = new MockMySQLiResult($this->getMockBuilder('mysqli_result')
-                                                        ->disableOriginalConstructor()
-                                                        ->getMock());
+        $this->queryResult = new MockMySQLiResult($this->getMockBuilder('mysqli_result')
+                                                       ->disableOriginalConstructor()
+                                                       ->getMock());
 
         $this->query = 'SELECT * FROM table';
 
-        $this->class = new MySQLQueryResult($this->query, $this->query_result, $this->mysqli);
+        $this->class = new MySQLQueryResult($this->query, $this->queryResult, $this->mysqli);
 
         parent::baseSetUp($this->class);
     }
@@ -74,13 +74,13 @@ abstract class MySQLQueryResultTestCase extends LunrBaseTestCase
      */
     public function failedSetup(): void
     {
-        $this->query_result = FALSE;
+        $this->queryResult = FALSE;
 
         $this->mysqli = new MockMySQLiFailedConnection($this->getMockBuilder('\mysqli')->getMock());
 
         $this->query = 'SELECT * FROM table';
 
-        $this->class = new MySQLQueryResult($this->query, $this->query_result, $this->mysqli);
+        $this->class = new MySQLQueryResult($this->query, $this->queryResult, $this->mysqli);
 
         parent::baseSetUp($this->class);
     }
@@ -92,13 +92,13 @@ abstract class MySQLQueryResultTestCase extends LunrBaseTestCase
      */
     public function successfulSetup(): void
     {
-        $this->query_result = TRUE;
+        $this->queryResult = TRUE;
 
         $this->mysqli = new MockMySQLiSuccessfulConnection($this->getMockBuilder('\mysqli')->getMock());
 
         $this->query = 'SELECT * FROM table';
 
-        $this->class = new MySQLQueryResult($this->query, $this->query_result, $this->mysqli);
+        $this->class = new MySQLQueryResult($this->query, $this->queryResult, $this->mysqli);
 
         parent::baseSetUp($this->class);
     }
@@ -112,13 +112,13 @@ abstract class MySQLQueryResultTestCase extends LunrBaseTestCase
     {
         $this->mysqli = new MockMySQLiSuccessfulWarningConnection($this->getMockBuilder('\mysqli')->getMock());
 
-        $this->query_result = new MockMySQLiResult($this->getMockBuilder('mysqli_result')
-                                                        ->disableOriginalConstructor()
-                                                        ->getMock());
+        $this->queryResult = new MockMySQLiResult($this->getMockBuilder('mysqli_result')
+                                                       ->disableOriginalConstructor()
+                                                       ->getMock());
 
         $this->query = 'SELECT * FROM table';
 
-        $this->class = new MySQLQueryResult($this->query, $this->query_result, $this->mysqli);
+        $this->class = new MySQLQueryResult($this->query, $this->queryResult, $this->mysqli);
 
         parent::baseSetUp($this->class);
     }
@@ -129,7 +129,7 @@ abstract class MySQLQueryResultTestCase extends LunrBaseTestCase
     public function tearDown(): void
     {
         unset($this->mysqli);
-        unset($this->query_result);
+        unset($this->queryResult);
         unset($this->query);
         unset($this->class);
 

--- a/tests/phpstan.neon.dist
+++ b/tests/phpstan.neon.dist
@@ -12,22 +12,6 @@ parameters:
         - ../src/*/Tests/*
     ignoreErrors:
         -
-            message: '#uninitialized readonly property \$escaper#'
-            paths:
-                - ../src/Lunr/Gravity/MySQL/MySQLConnection.php
-                - ../src/Lunr/Gravity/SQLite3/SQLite3Connection.php
+            identifier: property.uninitializedReadonly
         -
-            message: '#\$escaper is assigned outside of the constructor#'
-            paths:
-                - ../src/Lunr/Gravity/MySQL/MySQLConnection.php
-                - ../src/Lunr/Gravity/SQLite3/SQLite3Connection.php
-        -
-            message: '#uninitialized readonly property \$canonical_query#'
-            paths:
-                - ../src/Lunr/Gravity/MySQL/MySQLQueryResult.php
-                - ../src/Lunr/Gravity/MySQL/MySQLCanonicalQuery.php
-        -
-            message: '#\$canonical_query is assigned outside of the constructor#'
-            paths:
-                - ../src/Lunr/Gravity/MySQL/MySQLQueryResult.php
-                - ../src/Lunr/Gravity/MySQL/MySQLCanonicalQuery.php
+            identifier: property.readOnlyAssignNotInConstructor


### PR DESCRIPTION
I'm ignoreing the camelCase style check in the legacy test classes, since that would introduce breaking changes there.

I'm generalizing the ignore rules for readonly properties in phpstan, since the name changed and we encountered enough of them now to be able to tell we just want to generally disable it.