### PR TITLE
MySQL: Use return of mysqli::connect to determine connection status

### DIFF
--- a/src/Lunr/Gravity/MySQL/MySQLConnection.php
+++ b/src/Lunr/Gravity/MySQL/MySQLConnection.php
@@ -256,23 +256,18 @@ class MySQLConnection extends DatabaseConnection
             $this->mysqli->options($key, $value);
         }
 
-        $this->mysqli->connect($host, $this->user, $this->pwd, $this->db, $this->port, $this->socket);
+        $this->connected = $this->mysqli->connect($host, $this->user, $this->pwd, $this->db, $this->port, $this->socket);
 
-        if ($this->mysqli->errno === 0)
-        {
-            $this->connected = TRUE;
-
-            if ($this->mysqli->set_charset('utf8mb4') === FALSE)
-            {
-                // manual re-connect
-                $this->disconnect();
-                $this->connect(++$reconnect_count);
-            }
-        }
-
-        if ($this->connected === FALSE)
+        if ($this->connected === FALSE || $this->mysqli->connect_errno !== 0)
         {
             throw new ConnectionException('Could not establish connection to the database!');
+        }
+
+        if ($this->mysqli->set_charset('utf8mb4') === FALSE)
+        {
+            // manual re-connect
+            $this->disconnect();
+            $this->connect(++$reconnect_count);
         }
     }
 

--- a/src/Lunr/Gravity/MySQL/Tests/MockMySQLi.php
+++ b/src/Lunr/Gravity/MySQL/Tests/MockMySQLi.php
@@ -43,7 +43,7 @@ class MockMySQLi
     {
         switch ($name)
         {
-            case 'errno':
+            case 'connect_errno':
                 return 0;
         }
     }

--- a/src/Lunr/Gravity/MySQL/Tests/MockMySQLiFailedConnection.php
+++ b/src/Lunr/Gravity/MySQL/Tests/MockMySQLiFailedConnection.php
@@ -72,6 +72,8 @@ class MockMySQLiFailedConnection
                 return 10;
             case 'errno':
                 return 666;
+            case 'connect_errno':
+                return 666;
             case 'error':
                 return 'bad';
             case 'insert_id':
@@ -97,7 +99,7 @@ class MockMySQLiFailedConnection
      */
     public function connect($host, $user, $password, $database, $port, $socket)
     {
-        return TRUE;
+        return FALSE;
     }
 
     /**

--- a/src/Lunr/Gravity/MySQL/Tests/MySQLConnectionConnectTest.php
+++ b/src/Lunr/Gravity/MySQL/Tests/MySQLConnectionConnectTest.php
@@ -41,7 +41,8 @@ class MySQLConnectionConnectTest extends MySQLConnectionTest
 
         $mysqli->expects($this->once())
                ->method('connect')
-               ->with('ro_host', 'username', 'password', 'database', $port, $socket);
+               ->with('ro_host', 'username', 'password', 'database', $port, $socket)
+               ->willReturn(TRUE);
 
         $mysqli->expects($this->never())
                ->method('ssl_set');
@@ -77,7 +78,8 @@ class MySQLConnectionConnectTest extends MySQLConnectionTest
 
         $mysqli->expects($this->once())
                ->method('connect')
-               ->with('rw_host', 'username', 'password', 'database', $port, $socket);
+               ->with('rw_host', 'username', 'password', 'database', $port, $socket)
+               ->willReturn(TRUE);
 
         $mysqli->expects($this->never())
                ->method('ssl_set');
@@ -119,7 +121,8 @@ class MySQLConnectionConnectTest extends MySQLConnectionTest
 
         $mysqli->expects($this->once())
                ->method('connect')
-               ->with('rw_host', 'username', 'password', 'database', $port, $socket);
+               ->with('rw_host', 'username', 'password', 'database', $port, $socket)
+               ->willReturn(TRUE);
 
         $mysqli->expects($this->once())
                ->method('ssl_set')
@@ -162,7 +165,8 @@ class MySQLConnectionConnectTest extends MySQLConnectionTest
 
         $mysqli->expects($this->exactly(5))
                ->method('connect')
-               ->with('rw_host', 'username', 'password', 'database', $port, $socket);
+               ->with('rw_host', 'username', 'password', 'database', $port, $socket)
+               ->willReturn(TRUE);
 
         $mysqli->expects($this->exactly(5))
                ->method('ssl_set')
@@ -249,7 +253,8 @@ class MySQLConnectionConnectTest extends MySQLConnectionTest
 
         $mysqli->expects($this->exactly(5))
                ->method('connect')
-               ->with('rw_host', 'username', 'password', 'database', $port, $socket);
+               ->with('rw_host', 'username', 'password', 'database', $port, $socket)
+               ->willReturn(TRUE);
 
         $mysqli->expects($this->exactly(5))
                ->method('ssl_set')


### PR DESCRIPTION
[More info about the errors here https://www.php.net/manual/en/mysqli.construct.php#refsect1-mysqli.construct-errors](https://www.php.net/manual/en/mysqli.construct.php#refsect1-mysqli.construct-returnvalues) The return of mysqli::connect now always is a boolean. I tried it locally and this should more gracefully handle connect issues.