### PR TITLE
MariaDB/MySQL: Use properly initialized db connection class in test helpers

### DIFF
--- a/src/Lunr/Gravity/MariaDB/Tests/Helpers/AbstractMariaDBDatabaseAccessObjectLegacyTest.php
+++ b/src/Lunr/Gravity/MariaDB/Tests/Helpers/AbstractMariaDBDatabaseAccessObjectLegacyTest.php
@@ -15,6 +15,7 @@ use Lunr\Gravity\MariaDB\MariaDBDMLQueryBuilder;
 use Lunr\Gravity\MySQL\MySQLQueryEscaper;
 use Lunr\Gravity\MySQL\MySQLQueryResult;
 use Lunr\Halo\LegacyBaseTest;
+use MySQLi;
 use Psr\Log\LoggerInterface;
 use ReflectionClass;
 
@@ -61,8 +62,22 @@ abstract class AbstractMariaDBDatabaseAccessObjectLegacyTest extends LegacyBaseT
      */
     public function setUp(): void
     {
+        $this->logger = $this->getMockBuilder('Psr\Log\LoggerInterface')->getMock();
+
+        $mysqli = $this->getMockBuilder(MySQLi::class)
+                       ->disableOriginalConstructor()
+                       ->getMock();
+
+        $config = [
+            'rwHost'   => 'localhost',
+            'username' => 'user',
+            'password' => 'pass',
+            'database' => 'db',
+            'driver'   => 'mysql',
+        ];
+
         $this->db = $this->getMockBuilder('Lunr\Gravity\MariaDB\MariaDBConnection')
-                         ->disableOriginalConstructor()
+                         ->setConstructorArgs([ $config, $this->logger, $mysqli ])
                          ->getMock();
 
         $this->builder = $this->getMockBuilder('Lunr\Gravity\MariaDB\MariaDBDMLQueryBuilder')
@@ -76,8 +91,6 @@ abstract class AbstractMariaDBDatabaseAccessObjectLegacyTest extends LegacyBaseT
         $this->result = $this->getMockBuilder('Lunr\Gravity\MySQL\MySQLQueryResult')
                              ->disableOriginalConstructor()
                              ->getMock();
-
-        $this->logger = $this->getMockBuilder('Psr\Log\LoggerInterface')->getMock();
 
         $this->db->expects($this->once())
                  ->method('get_query_escaper_object')

--- a/src/Lunr/Gravity/MariaDB/Tests/Helpers/AbstractMariaDBDatabaseAccessObjectTestCase.php
+++ b/src/Lunr/Gravity/MariaDB/Tests/Helpers/AbstractMariaDBDatabaseAccessObjectTestCase.php
@@ -16,6 +16,7 @@ use Lunr\Gravity\MariaDB\MariaDBSimpleDMLQueryBuilder;
 use Lunr\Gravity\MySQL\MySQLQueryEscaper;
 use Lunr\Gravity\MySQL\MySQLQueryResult;
 use Lunr\Gravity\Tests\Helpers\DatabaseAccessObjectBaseTestCase;
+use MySQLi;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
 
@@ -90,8 +91,22 @@ abstract class AbstractMariaDBDatabaseAccessObjectTestCase extends DatabaseAcces
 
         $this->realSimpleBuilder = new MariaDBSimpleDMLQueryBuilder($this->realBuilder, $this->realEscaper);
 
+        $this->logger = $this->getMockBuilder('Psr\Log\LoggerInterface')->getMock();
+
+        $mysqli = $this->getMockBuilder(MySQLi::class)
+                       ->disableOriginalConstructor()
+                       ->getMock();
+
+        $config = [
+            'rwHost'   => 'localhost',
+            'username' => 'user',
+            'password' => 'pass',
+            'database' => 'db',
+            'driver'   => 'mysql',
+        ];
+
         $this->db = $this->getMockBuilder('Lunr\Gravity\MariaDB\MariaDBConnection')
-                         ->disableOriginalConstructor()
+                         ->setConstructorArgs([ $config, $this->logger, $mysqli ])
                          ->getMock();
 
         $this->builder = $this->getMockBuilder('Lunr\Gravity\MariaDB\MariaDBDMLQueryBuilder')
@@ -105,8 +120,6 @@ abstract class AbstractMariaDBDatabaseAccessObjectTestCase extends DatabaseAcces
         $this->result = $this->getMockBuilder('Lunr\Gravity\MariaDB\MySQLQueryResult')
                              ->disableOriginalConstructor()
                              ->getMock();
-
-        $this->logger = $this->getMockBuilder('Psr\Log\LoggerInterface')->getMock();
 
         $this->db->expects($this->exactly(1))
                  ->method('get_query_escaper_object')

--- a/src/Lunr/Gravity/MariaDB/Tests/Helpers/MariaDBDatabaseAccessObjectLegacyTest.php
+++ b/src/Lunr/Gravity/MariaDB/Tests/Helpers/MariaDBDatabaseAccessObjectLegacyTest.php
@@ -15,6 +15,7 @@ use Lunr\Gravity\MariaDB\MariaDBDMLQueryBuilder;
 use Lunr\Gravity\MySQL\MySQLQueryEscaper;
 use Lunr\Gravity\MySQL\MySQLQueryResult;
 use Lunr\Halo\LegacyBaseTest;
+use MySQLi;
 use Psr\Log\LoggerInterface;
 use ReflectionClass;
 
@@ -61,8 +62,22 @@ abstract class MariaDBDatabaseAccessObjectLegacyTest extends LegacyBaseTest
      */
     public function setUp(): void
     {
+        $this->logger = $this->getMockBuilder('Psr\Log\LoggerInterface')->getMock();
+
+        $mysqli = $this->getMockBuilder(MySQLi::class)
+                       ->disableOriginalConstructor()
+                       ->getMock();
+
+        $config = [
+            'rwHost'   => 'localhost',
+            'username' => 'user',
+            'password' => 'pass',
+            'database' => 'db',
+            'driver'   => 'mysql',
+        ];
+
         $this->db = $this->getMockBuilder('Lunr\Gravity\MariaDB\MariaDBConnection')
-                         ->disableOriginalConstructor()
+                         ->setConstructorArgs([ $config, $this->logger, $mysqli ])
                          ->getMock();
 
         $this->builder = $this->getMockBuilder('Lunr\Gravity\MariaDB\MariaDBDMLQueryBuilder')
@@ -76,8 +91,6 @@ abstract class MariaDBDatabaseAccessObjectLegacyTest extends LegacyBaseTest
         $this->result = $this->getMockBuilder('Lunr\Gravity\MySQL\MySQLQueryResult')
                              ->disableOriginalConstructor()
                              ->getMock();
-
-        $this->logger = $this->getMockBuilder('Psr\Log\LoggerInterface')->getMock();
 
         $this->db->expects($this->once())
                  ->method('get_query_escaper_object')

--- a/src/Lunr/Gravity/MariaDB/Tests/Helpers/MariaDBDatabaseAccessObjectTestCase.php
+++ b/src/Lunr/Gravity/MariaDB/Tests/Helpers/MariaDBDatabaseAccessObjectTestCase.php
@@ -16,6 +16,7 @@ use Lunr\Gravity\MariaDB\MariaDBSimpleDMLQueryBuilder;
 use Lunr\Gravity\MySQL\MySQLQueryEscaper;
 use Lunr\Gravity\MySQL\MySQLQueryResult;
 use Lunr\Gravity\Tests\Helpers\DatabaseAccessObjectBaseTestCase;
+use MySQLi;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -89,8 +90,22 @@ abstract class MariaDBDatabaseAccessObjectTestCase extends DatabaseAccessObjectB
 
         $this->realSimpleBuilder = new MariaDBSimpleDMLQueryBuilder($this->realBuilder, $this->realEscaper);
 
+        $this->logger = $this->getMockBuilder('Psr\Log\LoggerInterface')->getMock();
+
+        $mysqli = $this->getMockBuilder(MySQLi::class)
+                       ->disableOriginalConstructor()
+                       ->getMock();
+
+        $config = [
+            'rwHost'   => 'localhost',
+            'username' => 'user',
+            'password' => 'pass',
+            'database' => 'db',
+            'driver'   => 'mysql',
+        ];
+
         $this->db = $this->getMockBuilder('Lunr\Gravity\MariaDB\MariaDBConnection')
-                         ->disableOriginalConstructor()
+                         ->setConstructorArgs([ $config, $this->logger, $mysqli ])
                          ->getMock();
 
         $this->builder = $this->getMockBuilder('Lunr\Gravity\MariaDB\MariaDBDMLQueryBuilder')
@@ -104,8 +119,6 @@ abstract class MariaDBDatabaseAccessObjectTestCase extends DatabaseAccessObjectB
         $this->result = $this->getMockBuilder('Lunr\Gravity\MySQL\MySQLQueryResult')
                              ->disableOriginalConstructor()
                              ->getMock();
-
-        $this->logger = $this->getMockBuilder('Psr\Log\LoggerInterface')->getMock();
 
         $this->db->expects($this->once())
                  ->method('get_query_escaper_object')

--- a/src/Lunr/Gravity/MySQL/Tests/Helpers/AbstractMySQLDatabaseAccessObjectLegacyTest.php
+++ b/src/Lunr/Gravity/MySQL/Tests/Helpers/AbstractMySQLDatabaseAccessObjectLegacyTest.php
@@ -16,6 +16,7 @@ use Lunr\Gravity\MySQL\MySQLQueryEscaper;
 use Lunr\Gravity\MySQL\MySQLQueryResult;
 use Lunr\Gravity\MySQL\MySQLSimpleDMLQueryBuilder;
 use Lunr\Halo\LegacyBaseTest;
+use MySQLi;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
 use ReflectionClass;
@@ -96,8 +97,22 @@ abstract class AbstractMySQLDatabaseAccessObjectLegacyTest extends LegacyBaseTes
 
         $this->real_simple_builder = new MySQLSimpleDMLQueryBuilder($this->real_builder, $this->real_escaper);
 
+        $this->logger = $this->getMockBuilder('Psr\Log\LoggerInterface')->getMock();
+
+        $mysqli = $this->getMockBuilder(MySQLi::class)
+                       ->disableOriginalConstructor()
+                       ->getMock();
+
+        $config = [
+            'rwHost'   => 'localhost',
+            'username' => 'user',
+            'password' => 'pass',
+            'database' => 'db',
+            'driver'   => 'mysql',
+        ];
+
         $this->db = $this->getMockBuilder('Lunr\Gravity\MySQL\MySQLConnection')
-                         ->disableOriginalConstructor()
+                         ->setConstructorArgs([ $config, $this->logger, $mysqli ])
                          ->getMock();
 
         $this->builder = $this->getMockBuilder('Lunr\Gravity\MySQL\MySQLDMLQueryBuilder')
@@ -111,8 +126,6 @@ abstract class AbstractMySQLDatabaseAccessObjectLegacyTest extends LegacyBaseTes
         $this->result = $this->getMockBuilder('Lunr\Gravity\MySQL\MySQLQueryResult')
                              ->disableOriginalConstructor()
                              ->getMock();
-
-        $this->logger = $this->getMockBuilder('Psr\Log\LoggerInterface')->getMock();
 
         $this->db->expects($this->exactly(1))
                  ->method('get_query_escaper_object')

--- a/src/Lunr/Gravity/MySQL/Tests/Helpers/AbstractMySQLDatabaseAccessObjectTestCase.php
+++ b/src/Lunr/Gravity/MySQL/Tests/Helpers/AbstractMySQLDatabaseAccessObjectTestCase.php
@@ -16,6 +16,7 @@ use Lunr\Gravity\MySQL\MySQLQueryEscaper;
 use Lunr\Gravity\MySQL\MySQLQueryResult;
 use Lunr\Gravity\MySQL\MySQLSimpleDMLQueryBuilder;
 use Lunr\Gravity\Tests\Helpers\DatabaseAccessObjectBaseTestCase;
+use MySQLi;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
 
@@ -90,8 +91,22 @@ abstract class AbstractMySQLDatabaseAccessObjectTestCase extends DatabaseAccessO
 
         $this->realSimpleBuilder = new MySQLSimpleDMLQueryBuilder($this->realBuilder, $this->realEscaper);
 
+        $this->logger = $this->getMockBuilder('Psr\Log\LoggerInterface')->getMock();
+
+        $mysqli = $this->getMockBuilder(MySQLi::class)
+                       ->disableOriginalConstructor()
+                       ->getMock();
+
+        $config = [
+            'rwHost'   => 'localhost',
+            'username' => 'user',
+            'password' => 'pass',
+            'database' => 'db',
+            'driver'   => 'mysql',
+        ];
+
         $this->db = $this->getMockBuilder('Lunr\Gravity\MySQL\MySQLConnection')
-                         ->disableOriginalConstructor()
+                         ->setConstructorArgs([ $config, $this->logger, $mysqli ])
                          ->getMock();
 
         $this->builder = $this->getMockBuilder('Lunr\Gravity\MySQL\MySQLDMLQueryBuilder')
@@ -105,8 +120,6 @@ abstract class AbstractMySQLDatabaseAccessObjectTestCase extends DatabaseAccessO
         $this->result = $this->getMockBuilder('Lunr\Gravity\MySQL\MySQLQueryResult')
                              ->disableOriginalConstructor()
                              ->getMock();
-
-        $this->logger = $this->getMockBuilder('Psr\Log\LoggerInterface')->getMock();
 
         $this->db->expects($this->exactly(1))
                  ->method('get_query_escaper_object')

--- a/src/Lunr/Gravity/MySQL/Tests/Helpers/MySQLDatabaseAccessObjectLegacyTest.php
+++ b/src/Lunr/Gravity/MySQL/Tests/Helpers/MySQLDatabaseAccessObjectLegacyTest.php
@@ -16,6 +16,7 @@ use Lunr\Gravity\MySQL\MySQLQueryEscaper;
 use Lunr\Gravity\MySQL\MySQLQueryResult;
 use Lunr\Gravity\MySQL\MySQLSimpleDMLQueryBuilder;
 use Lunr\Halo\LegacyBaseTest;
+use MySQLi;
 use Psr\Log\LoggerInterface;
 use ReflectionClass;
 
@@ -95,8 +96,22 @@ abstract class MySQLDatabaseAccessObjectLegacyTest extends LegacyBaseTest
 
         $this->real_simple_builder = new MySQLSimpleDMLQueryBuilder($this->real_builder, $this->real_escaper);
 
+        $this->logger = $this->getMockBuilder('Psr\Log\LoggerInterface')->getMock();
+
+        $mysqli = $this->getMockBuilder(MySQLi::class)
+                       ->disableOriginalConstructor()
+                       ->getMock();
+
+        $config = [
+            'rwHost'   => 'localhost',
+            'username' => 'user',
+            'password' => 'pass',
+            'database' => 'db',
+            'driver'   => 'mysql',
+        ];
+
         $this->db = $this->getMockBuilder('Lunr\Gravity\MySQL\MySQLConnection')
-                         ->disableOriginalConstructor()
+                         ->setConstructorArgs([ $config, $this->logger, $mysqli ])
                          ->getMock();
 
         $this->builder = $this->getMockBuilder('Lunr\Gravity\MySQL\MySQLDMLQueryBuilder')
@@ -110,8 +125,6 @@ abstract class MySQLDatabaseAccessObjectLegacyTest extends LegacyBaseTest
         $this->result = $this->getMockBuilder('Lunr\Gravity\MySQL\MySQLQueryResult')
                              ->disableOriginalConstructor()
                              ->getMock();
-
-        $this->logger = $this->getMockBuilder('Psr\Log\LoggerInterface')->getMock();
 
         $this->db->expects($this->once())
                  ->method('get_query_escaper_object')

--- a/src/Lunr/Gravity/MySQL/Tests/Helpers/MySQLDatabaseAccessObjectTestCase.php
+++ b/src/Lunr/Gravity/MySQL/Tests/Helpers/MySQLDatabaseAccessObjectTestCase.php
@@ -16,6 +16,7 @@ use Lunr\Gravity\MySQL\MySQLQueryEscaper;
 use Lunr\Gravity\MySQL\MySQLQueryResult;
 use Lunr\Gravity\MySQL\MySQLSimpleDMLQueryBuilder;
 use Lunr\Gravity\Tests\Helpers\DatabaseAccessObjectBaseTestCase;
+use MySQLi;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -89,13 +90,23 @@ abstract class MySQLDatabaseAccessObjectTestCase extends DatabaseAccessObjectBas
 
         $this->realSimpleBuilder = new MySQLSimpleDMLQueryBuilder($this->realBuilder, $this->realEscaper);
 
-        $this->db = $this->getMockBuilder('Lunr\Gravity\MySQL\MySQLConnection')
-                         ->disableOriginalConstructor()
-                         ->getMock();
+        $this->logger = $this->getMockBuilder('Psr\Log\LoggerInterface')->getMock();
 
-        $this->builder = $this->getMockBuilder('Lunr\Gravity\MySQL\MySQLDMLQueryBuilder')
-                              ->disableOriginalConstructor()
-                              ->getMock();
+        $mysqli = $this->getMockBuilder(MySQLi::class)
+                       ->disableOriginalConstructor()
+                       ->getMock();
+
+        $config = [
+            'rwHost'   => 'localhost',
+            'username' => 'user',
+            'password' => 'pass',
+            'database' => 'db',
+            'driver'   => 'mysql',
+        ];
+
+        $this->db = $this->getMockBuilder('Lunr\Gravity\MySQL\MySQLConnection')
+                         ->setConstructorArgs([ $config, $this->logger, $mysqli ])
+                         ->getMock();
 
         $this->escaper = $this->getMockBuilder('Lunr\Gravity\MySQL\MySQLQueryEscaper')
                               ->disableOriginalConstructor()
@@ -104,8 +115,6 @@ abstract class MySQLDatabaseAccessObjectTestCase extends DatabaseAccessObjectBas
         $this->result = $this->getMockBuilder('Lunr\Gravity\MySQL\MySQLQueryResult')
                              ->disableOriginalConstructor()
                              ->getMock();
-
-        $this->logger = $this->getMockBuilder('Psr\Log\LoggerInterface')->getMock();
 
         $this->db->expects($this->once())
                  ->method('get_query_escaper_object')


### PR DESCRIPTION
This fixes issues when the `connected` and `readonly` properties aren't initialized.