### PR TITLE
MariaDB/MySQL: Use constructor for test mocks of connection class

### DIFF
--- a/src/Lunr/Gravity/MariaDB/Tests/MariaDBAccessObjectBaseTest.php
+++ b/src/Lunr/Gravity/MariaDB/Tests/MariaDBAccessObjectBaseTest.php
@@ -12,6 +12,7 @@ namespace Lunr\Gravity\MariaDB\Tests;
 use Lunr\Gravity\MariaDB\MariaDBConnection;
 use Lunr\Gravity\MySQL\MySQLQueryEscaper;
 use Lunr\Halo\PropertyTraits\PsrLoggerTestTrait;
+use MySQLi;
 
 /**
  * This class contains the tests for the MariaDBAccessObject class.
@@ -50,8 +51,16 @@ class MariaDBAccessObjectBaseTest extends MariaDBAccessObjectTestCase
      */
     public function testSwapConnectionSwapsConnection(): void
     {
+        $config = [
+            'rwHost'   => 'rwHost',
+            'username' => 'username',
+            'password' => 'password',
+            'database' => 'database',
+            'driver'   => 'mariadb',
+        ];
+
         $db = $this->getMockBuilder(MariaDBConnection::class)
-                   ->disableOriginalConstructor()
+                   ->setConstructorArgs([ $config, $this->logger, new MySQLi() ])
                    ->getMock();
 
         $escaper = $this->getMockBuilder(MySQLQueryEscaper::class)
@@ -85,8 +94,16 @@ class MariaDBAccessObjectBaseTest extends MariaDBAccessObjectTestCase
      */
     public function testSwapConnectionSwapsQueryEscaper(): void
     {
+        $config = [
+            'rwHost'   => 'rwHost',
+            'username' => 'username',
+            'password' => 'password',
+            'database' => 'database',
+            'driver'   => 'mariadb',
+        ];
+
         $db = $this->getMockBuilder(MariaDBConnection::class)
-                   ->disableOriginalConstructor()
+                   ->setConstructorArgs([ $config, $this->logger, new MySQLi() ])
                    ->getMock();
 
         $escaper = $this->getMockBuilder(MySQLQueryEscaper::class)

--- a/src/Lunr/Gravity/MariaDB/Tests/MariaDBAccessObjectTestCase.php
+++ b/src/Lunr/Gravity/MariaDB/Tests/MariaDBAccessObjectTestCase.php
@@ -13,6 +13,7 @@ use Lunr\Gravity\MariaDB\MariaDBAccessObject;
 use Lunr\Gravity\MariaDB\MariaDBConnection;
 use Lunr\Gravity\MySQL\MySQLQueryEscaper;
 use Lunr\Halo\LunrBaseTestCase;
+use MySQLi;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\MockObject\Stub;
 use Psr\Log\LoggerInterface;
@@ -52,8 +53,16 @@ abstract class MariaDBAccessObjectTestCase extends LunrBaseTestCase
     {
         $this->logger = $this->getMockBuilder(LoggerInterface::class)->getMock();
 
+        $config = [
+            'rwHost'   => 'rwHost',
+            'username' => 'username',
+            'password' => 'password',
+            'database' => 'database',
+            'driver'   => 'mariadb',
+        ];
+
         $this->db = $this->getMockBuilder(MariaDBConnection::class)
-                         ->disableOriginalConstructor()
+                         ->setConstructorArgs([ $config, $this->logger, new MySQLi() ])
                          ->getMock();
 
         $escaper = $this->getMockBuilder(MySQLQueryEscaper::class)

--- a/src/Lunr/Gravity/MariaDB/Tests/TransactionalMariaDBAccessObjectTestCase.php
+++ b/src/Lunr/Gravity/MariaDB/Tests/TransactionalMariaDBAccessObjectTestCase.php
@@ -13,6 +13,7 @@ use Lunr\Gravity\MariaDB\MariaDBConnection;
 use Lunr\Gravity\MariaDB\TransactionalMariaDBAccessObject;
 use Lunr\Gravity\MySQL\MySQLQueryEscaper;
 use Lunr\Halo\LunrBaseTestCase;
+use MySQLi;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\MockObject\Stub;
 use Psr\Log\LoggerInterface;
@@ -52,8 +53,16 @@ abstract class TransactionalMariaDBAccessObjectTestCase extends LunrBaseTestCase
     {
         $this->logger = $this->getMockBuilder(LoggerInterface::class)->getMock();
 
+        $config = [
+            'rwHost'   => 'rwHost',
+            'username' => 'username',
+            'password' => 'password',
+            'database' => 'database',
+            'driver'   => 'mariadb',
+        ];
+
         $this->db = $this->getMockBuilder(MariaDBConnection::class)
-                         ->disableOriginalConstructor()
+                         ->setConstructorArgs([ $config, $this->logger, new MySQLi() ])
                          ->getMock();
 
         $escaper = $this->getMockBuilder(MySQLQueryEscaper::class)

--- a/src/Lunr/Gravity/MySQL/Tests/MySQLAccessObjectBaseTest.php
+++ b/src/Lunr/Gravity/MySQL/Tests/MySQLAccessObjectBaseTest.php
@@ -12,6 +12,7 @@ namespace Lunr\Gravity\MySQL\Tests;
 use Lunr\Gravity\MySQL\MySQLConnection;
 use Lunr\Gravity\MySQL\MySQLQueryEscaper;
 use Lunr\Halo\PropertyTraits\PsrLoggerTestTrait;
+use MySQLi;
 
 /**
  * This class contains the tests for the MySQLAccessObject class.
@@ -50,8 +51,16 @@ class MySQLAccessObjectBaseTest extends MySQLAccessObjectTestCase
      */
     public function testSwapConnectionSwapsConnection(): void
     {
+        $config = [
+            'rwHost'   => 'rwHost',
+            'username' => 'username',
+            'password' => 'password',
+            'database' => 'database',
+            'driver'   => 'mariadb',
+        ];
+
         $db = $this->getMockBuilder(MySQLConnection::class)
-                   ->disableOriginalConstructor()
+                   ->setConstructorArgs([ $config, $this->logger, new MySQLi() ])
                    ->getMock();
 
         $escaper = $this->getMockBuilder(MySQLQueryEscaper::class)
@@ -85,8 +94,16 @@ class MySQLAccessObjectBaseTest extends MySQLAccessObjectTestCase
      */
     public function testSwapConnectionSwapsQueryEscaper(): void
     {
+        $config = [
+            'rwHost'   => 'rwHost',
+            'username' => 'username',
+            'password' => 'password',
+            'database' => 'database',
+            'driver'   => 'mariadb',
+        ];
+
         $db = $this->getMockBuilder(MySQLConnection::class)
-                   ->disableOriginalConstructor()
+                   ->setConstructorArgs([ $config, $this->logger, new MySQLi() ])
                    ->getMock();
 
         $escaper = $this->getMockBuilder(MySQLQueryEscaper::class)

--- a/src/Lunr/Gravity/MySQL/Tests/MySQLAccessObjectTestCase.php
+++ b/src/Lunr/Gravity/MySQL/Tests/MySQLAccessObjectTestCase.php
@@ -13,6 +13,7 @@ use Lunr\Gravity\MySQL\MySQLAccessObject;
 use Lunr\Gravity\MySQL\MySQLConnection;
 use Lunr\Gravity\MySQL\MySQLQueryEscaper;
 use Lunr\Halo\LunrBaseTestCase;
+use MySQLi;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\MockObject\Stub;
 use Psr\Log\LoggerInterface;
@@ -52,8 +53,16 @@ abstract class MySQLAccessObjectTestCase extends LunrBaseTestCase
     {
         $this->logger = $this->getMockBuilder(LoggerInterface::class)->getMock();
 
+        $config = [
+            'rwHost'   => 'rwHost',
+            'username' => 'username',
+            'password' => 'password',
+            'database' => 'database',
+            'driver'   => 'mariadb',
+        ];
+
         $this->db = $this->getMockBuilder(MySQLConnection::class)
-                         ->disableOriginalConstructor()
+                         ->setConstructorArgs([ $config, $this->logger, new MySQLi() ])
                          ->getMock();
 
         $escaper = $this->getMockBuilder(MySQLQueryEscaper::class)

--- a/src/Lunr/Gravity/MySQL/Tests/TransactionalMySQLAccessObjectTestCase.php
+++ b/src/Lunr/Gravity/MySQL/Tests/TransactionalMySQLAccessObjectTestCase.php
@@ -13,6 +13,7 @@ use Lunr\Gravity\MySQL\MySQLConnection;
 use Lunr\Gravity\MySQL\MySQLQueryEscaper;
 use Lunr\Gravity\MySQL\TransactionalMySQLAccessObject;
 use Lunr\Halo\LunrBaseTestCase;
+use MySQLi;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\MockObject\Stub;
 use Psr\Log\LoggerInterface;
@@ -52,8 +53,16 @@ abstract class TransactionalMySQLAccessObjectTestCase extends LunrBaseTestCase
     {
         $this->logger = $this->getMockBuilder(LoggerInterface::class)->getMock();
 
+        $config = [
+            'rwHost'   => 'rwHost',
+            'username' => 'username',
+            'password' => 'password',
+            'database' => 'database',
+            'driver'   => 'mariadb',
+        ];
+
         $this->db = $this->getMockBuilder(MySQLConnection::class)
-                         ->disableOriginalConstructor()
+                         ->setConstructorArgs([ $config, $this->logger, new MySQLi() ])
                          ->getMock();
 
         $escaper = $this->getMockBuilder(MySQLQueryEscaper::class)


### PR DESCRIPTION
This avoids errors with PHPUnit about uninitialized properties