### PR TITLE
Database: Make sure indexed_result_array() behaves correctly with non-string indexes

### DIFF
--- a/src/Lunr/Gravity/DatabaseAccessObject.php
+++ b/src/Lunr/Gravity/DatabaseAccessObject.php
@@ -147,7 +147,7 @@ abstract class DatabaseAccessObject
 
         foreach ($query->result_array() as $row)
         {
-            $result[$row[$column]] = $row;
+            $result[(string) $row[$column]] = $row;
         }
 
         return $result;

--- a/src/Lunr/Gravity/Tests/DatabaseAccessObjectResultsTest.php
+++ b/src/Lunr/Gravity/Tests/DatabaseAccessObjectResultsTest.php
@@ -112,7 +112,11 @@ class DatabaseAccessObjectResultsTest extends DatabaseAccessObjectTestCase
             ],
             [
                 'key'  => 'value2',
-                'key2' => 'index2',
+                'key2' => 123,
+            ],
+            [
+                'key'  => 'value3',
+                'key2' => 123.4,
             ],
         ];
 
@@ -129,14 +133,18 @@ class DatabaseAccessObjectResultsTest extends DatabaseAccessObjectTestCase
                 'key'  => 'value',
                 'key2' => 'index',
             ],
-            'index2' => [
+            '123' => [
                 'key'  => 'value2',
-                'key2' => 'index2',
+                'key2' => 123,
+            ],
+            '123.4' => [
+                'key'  => 'value3',
+                'key2' => 123.4,
             ],
         ];
 
         $this->assertIsArray($result);
-        $this->assertEquals($indexedResult, $result);
+        $this->assertSame($indexedResult, $result);
     }
 
     /**


### PR DESCRIPTION
Cast all values to string to make the indexes predictable. Theoretically int indexes could be kept, but casting them to int avoids potential corner cases.